### PR TITLE
Deploy 'gl-pages' only

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,10 @@ stages:
   - report
   - deploy
 
+workflow:
+  rules:
+    - if: $CI_COMMIT_REF_NAME != "gl-pages"
+
 test:
   stage: test
   allow_failure: true
@@ -47,24 +51,23 @@ allure:
     - cd $CI_PROJECT_NAME
     - git config user.name "Gitlab Runner"
     - git config user.email ${CI_EMAIL}
-    - git remote add $CI_PROJECT_NAME https://oauth2:${ALLURE_GITLAB_PAGES}@${CI_SERVER_HOST}/${CI_PROJECT_NAMESPACE}/${CI_PROJECT_NAME}.git
+    - git remote add $CI_PROJECT_NAME https://oauth2:${ALLURE_GITLAB_PAGES}@${CI_REPOSITORY_URL}
     - git add ./public
     - git commit -m "pipeline_${CI_PIPELINE_ID}_job_${CI_JOB_ID}"
     - git push -u $CI_PROJECT_NAME
-  artifacts:
-    when: on_success
-    expire_in: 3 days
-    paths:
-      - public
+  after_script:
+    - >
+      curl --request POST --header "PRIVATE-TOKEN: ${ALLURE_GITLAB_PAGES}"
+      "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/pipeline?ref=gl-pages"
 
 pages:
   image: python:3.7-alpine
   stage: deploy
-  when: on_success
   script:
     - python3 generate_index.py public
     - python3 generate_index.py public/${CI_COMMIT_REF_NAME}
+  rules:
+    - if: $CI_COMMIT_REF_NAME == 'gl-pages'
   artifacts:
-    expire_in: 3 days
     paths:
       - public

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,7 +54,7 @@ allure:
 
     - git config user.name "Gitlab Runner"
     - git config user.email ${CI_EMAIL}
-    - git remote add $CI_PROJECT_NAME https://oauth2:${ALLURE_GITLAB_PAGES}@${CI_REPOSITORY_URL}
+    - git remote add $CI_PROJECT_NAME oauth2:${ALLURE_GITLAB_PAGES}@${CI_REPOSITORY_URL}
     - git add ./public
     - git commit -m "pipeline_${CI_PIPELINE_ID}_job_${CI_JOB_ID}"
     - git push -u $CI_PROJECT_NAME

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,7 +47,7 @@ allure:
     - mkdir -p ${CURRENT_BRANCH}
     - cp -r $REPORT ${CURRENT_BRANCH}
     - cp -r ${CI_PROJECT_NAME}/public ./public
-
+    - cp -r generate_index.py $CI_PROJECT_NAME
     - cd $CI_PROJECT_NAME
     - python3 generate_index.py public
     - python3 generate_index.py public/${CI_COMMIT_REF_NAME}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: registry.gitlab.com/aleksandr-kotlyar/gitlab-allure-history:v4
+image: registry.gitlab.com/aleksandr-kotlyar/gitlab-allure-history:v3
 
 stages:
   - test
@@ -55,19 +55,3 @@ allure:
     - git add ./public
     - git commit -m "pipeline_${CI_PIPELINE_ID}_job_${CI_JOB_ID}"
     - git push -u $CI_PROJECT_NAME
-  after_script:
-    - >
-      curl --request POST --header "PRIVATE-TOKEN: ${PRIVATE_API_TOKEN}"
-      "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/pipeline?ref=gl-pages"
-
-pages:
-  image: python:3.7-alpine
-  stage: deploy
-  script:
-    - python3 generate_index.py public
-    - python3 generate_index.py public/${CI_COMMIT_REF_NAME}
-  rules:
-    - if: $CI_COMMIT_REF_NAME == 'gl-pages'
-  artifacts:
-    paths:
-      - public

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,7 +57,7 @@ allure:
     - git push -u $CI_PROJECT_NAME
   after_script:
     - >
-      curl --request POST --header "PRIVATE-TOKEN: ${ALLURE_GITLAB_PAGES}"
+      curl --request POST --header "PRIVATE-TOKEN: ${PRIVATE_API_TOKEN}"
       "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/pipeline?ref=gl-pages"
 
 pages:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,6 +49,9 @@ allure:
     - cp -r ${CI_PROJECT_NAME}/public ./public
 
     - cd $CI_PROJECT_NAME
+    - python3 generate_index.py public
+    - python3 generate_index.py public/${CI_COMMIT_REF_NAME}
+
     - git config user.name "Gitlab Runner"
     - git config user.email ${CI_EMAIL}
     - git remote add $CI_PROJECT_NAME https://oauth2:${ALLURE_GITLAB_PAGES}@${CI_REPOSITORY_URL}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,11 +3,6 @@ image: registry.gitlab.com/aleksandr-kotlyar/gitlab-allure-history:v3
 stages:
   - test
   - report
-  - deploy
-
-workflow:
-  rules:
-    - if: $CI_COMMIT_REF_NAME != "gl-pages"
 
 test:
   stage: test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,7 +54,9 @@ allure:
 
     - git config user.name "Gitlab Runner"
     - git config user.email ${CI_EMAIL}
-    - git remote add $CI_PROJECT_NAME oauth2:${ALLURE_GITLAB_PAGES}@${CI_REPOSITORY_URL}
+    - >
+      git remote add $CI_PROJECT_NAME 
+      https://oauth2:${ALLURE_GITLAB_PAGES}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git
     - git add ./public
     - git commit -m "pipeline_${CI_PIPELINE_ID}_job_${CI_JOB_ID}"
     - git push -u $CI_PROJECT_NAME

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: registry.gitlab.com/aleksandr-kotlyar/gitlab-allure-history:v3
+image: registry.gitlab.com/aleksandr-kotlyar/gitlab-allure-history:v4
 
 stages:
   - test

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY --from=compile-image /app/venv /app/venv
 
 RUN apk --no-cache add \
     git=2.30.1-r0 \
+    curl=7.74.0-r1 \
     openjdk8-jre=8.275.01-r0 \
     && rm -rf /var/cache/apk/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ COPY --from=compile-image /app/venv /app/venv
 
 RUN apk --no-cache add \
     git=2.30.1-r0 \
-    curl=7.74.0-r1 \
     openjdk8-jre=8.275.01-r0 \
     && rm -rf /var/cache/apk/*
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Here is how it works:
    4. Generates report with allure Commandline into job_number build folder.
    5. Creates branch-dir in 'gl-pages' `/public` directory if it's not existed yet.    
    5. Copies report into 'gl-pages' `/public/branch` directory: `/public/branch/job_number`.
-   6. Commits and pushes the public directory into 'gl-pages' branch into the repo.
+   6. Generates the index files for page tree `/public` and `/public/branch`.
+   7. Commits and pushes the public directory into 'gl-pages' branch into the repo.
 3. And then push to branch 'gl-pages' triggers it's own job `pages` which publishes all 
    content from `/public` directory on GitLab Pages. You can open root link of GitLab Pages and 
    always see all the history of each branch and find the latest execution by the latest 


### PR DESCRIPTION
1. Generate indexes before commit to 'gl-pages'.
2. Publish only in 'gl-pages'.

Also, resolves #12 .