### PR TITLE
Fix bug with history trends

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,23 +25,21 @@ allure:
     - JOB_ID=$(cat jobid)
     - REPORT=job_${JOB_ID}
     - CURRENT_BRANCH=${CI_PROJECT_NAME}/public/${CI_COMMIT_REF_NAME}
-    - LAST=${CURRENT_BRANCH}/$(cd ${CURRENT_BRANCH}; ls -td -- */ | head -n 1)
-    - cp -r ./${LAST}history allure-results || echo "No history"
+    - cp -r ./${CURRENT_BRANCH}/history allure-results || echo "No history"
 
     #echo "executor.json"
     - echo '{"name":"GitLabCI","type":"gitlab","reportName":"Allure Report with history",' > executor.json
-    - echo "\"url\":\"${CI_PAGES_DOMAIN}/${CURRENT_BRANCH}\"," >> executor.json
     - echo "\"reportUrl\":\"${CI_PAGES_DOMAIN}/${CURRENT_BRANCH}/${REPORT}/\"," >> executor.json
     - echo "\"buildUrl\":\"${CI_PIPELINE_URL}\"," >> executor.json
-    - echo "\"buildName\":\"GitLab Job Run `#`${JOB_ID}\",\"buildOrder\":\"${JOB_ID}\"}" >> executor.json
+    - echo "\"buildName\":\"GitLab Job Run ${JOB_ID}\",\"buildOrder\":\"${JOB_ID}\"}" >> executor.json
     #cat executor.json
     - mv ./executor.json ./allure-results
 
     - allure generate allure-results -o $REPORT
 
-    - mkdir -p ${CURRENT_BRANCH}
-    - cp -r $REPORT ${CURRENT_BRANCH}
-    - cp -r ${CI_PROJECT_NAME}/public ./public
+    - mkdir -p $CURRENT_BRANCH
+    - cp -r $REPORT $CURRENT_BRANCH
+    - cp -r ${REPORT}/history $CURRENT_BRANCH
     - cp -r generate_index.py $CI_PROJECT_NAME
     - cd $CI_PROJECT_NAME
     - python3 generate_index.py public


### PR DESCRIPTION
## What?
There is a bug that history trend is not deeper than 2-3 builds.

## Cause?
The git clone - creates files with current created date and the script which takes the LAST build by date, always took the same build, so that's why trends were broken.

## Plan to fix
1. Copy history of current build in separately into the branch-dir.
2. Always copy history from the branch-dir, not calculate "latest" build by date because it's compromised.