### PR TITLE
Add sticky breadcrumb navigation to generated indexes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -186,8 +186,7 @@ allure:
 
       python3 prune_reports.py "$BRANCH_PUBLIC_DIR" "$REPORTS_TO_KEEP"
 
-      python3 generate_index.py "$PAGES_PUBLIC_DIR"
-      python3 generate_index.py "$BRANCH_PUBLIC_DIR"
+      python3 generate_index.py --recursive "$PAGES_PUBLIC_DIR"
 
     - |
       git -C pages-worktree config user.name "GitLab Runner"

--- a/generate_index.py
+++ b/generate_index.py
@@ -81,6 +81,19 @@ STYLE = """
             overflow-wrap: anywhere;
         }
 
+        .breadcrumbs {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: baseline;
+            min-width: 0;
+        }
+
+        .breadcrumb-separator {
+            margin: 0 4px;
+            color: var(--muted);
+            font-weight: 500;
+        }
+
         .theme-toggle {
             min-width: 72px;
             min-height: 34px;
@@ -342,6 +355,28 @@ def iter_entries(folder: Path) -> list[Path]:
     )
 
 
+def is_indexable_folder(folder: Path) -> bool:
+    return folder.is_dir() and folder.name not in HIDDEN_INDEX_ENTRIES and job_id(folder) is None
+
+
+def iter_index_folders(root: Path) -> list[Path]:
+    folders: list[Path] = []
+
+    def collect(folder: Path) -> None:
+        folders.append(folder)
+
+        children = sorted(
+            (entry for entry in folder.iterdir() if is_indexable_folder(entry)),
+            key=lambda entry: (entry.name.casefold(), entry.name),
+        )
+
+        for child in children:
+            collect(child)
+
+    collect(root)
+    return folders
+
+
 def link_for(entry: Path) -> str:
     suffix = "/" if entry.is_dir() else ""
     return quote(entry.name, safe="") + suffix
@@ -362,6 +397,47 @@ def display_path(folder: Path) -> str:
     suffix_parts = parts[public_index + 1 :]
 
     return "/".join([PUBLIC_TITLE, *suffix_parts])
+
+
+def public_suffix_parts(folder: Path) -> list[str] | None:
+    parts = folder.as_posix().split("/")
+
+    if ROOT_INDEX_DIR not in parts:
+        return None
+
+    public_index = len(parts) - 1 - parts[::-1].index(ROOT_INDEX_DIR)
+    return parts[public_index + 1 :]
+
+
+def breadcrumb_html(folder: Path) -> str:
+    suffix_parts = public_suffix_parts(folder)
+
+    if suffix_parts is None:
+        return f"<h1>{escape(folder.as_posix())}</h1>"
+
+    crumbs = [PUBLIC_TITLE, *suffix_parts]
+    last_index = len(crumbs) - 1
+    html_parts: list[str] = ['<h1 class="breadcrumbs" aria-label="Current location">']
+
+    for index, crumb in enumerate(crumbs):
+        if index:
+            html_parts.append('<span class="breadcrumb-separator">/</span>')
+
+        levels_up = last_index - index
+
+        if levels_up:
+            href = "../" * levels_up
+            html_parts.append(
+                '<a href="{href}">{label}</a>'.format(
+                    href=escape(href, quote=True),
+                    label=escape(crumb),
+                )
+            )
+        else:
+            html_parts.append(f'<span aria-current="page">{escape(crumb)}</span>')
+
+    html_parts.append("</h1>")
+    return "".join(html_parts)
 
 
 def show_parent_link(folder: Path) -> bool:
@@ -428,7 +504,7 @@ def build_index_html(folder: Path, entries: list[Path]) -> str:
 <body>
     <main>
         <div class="page-header">
-            <h1>{escape(title)}</h1>
+            {breadcrumb_html(folder)}
             <button class="theme-toggle" type="button" aria-label="Switch theme" title="Switch theme">Theme</button>
         </div>
         <table>
@@ -463,9 +539,20 @@ def index_folder(folder: str | Path) -> Path:
     return index_path
 
 
+def index_tree(root: str | Path) -> list[Path]:
+    path = Path(root)
+    path.mkdir(parents=True, exist_ok=True)
+
+    return [index_folder(folder) for folder in iter_index_folders(path)]
+
+
 def main(argv: list[str]) -> int:
+    if len(argv) == 3 and argv[1] == "--recursive":
+        index_tree(argv[2])
+        return 0
+
     if len(argv) != 2:
-        print("Usage: python3 generate_index.py <folder>", file=sys.stderr)
+        print("Usage: python3 generate_index.py [--recursive] <folder>", file=sys.stderr)
         return 2
 
     index_folder(argv[1])

--- a/tests/test_generate_index.py
+++ b/tests/test_generate_index.py
@@ -1,4 +1,4 @@
-from generate_index import index_folder
+from generate_index import index_folder, index_tree
 
 
 def test_index_folder_creates_empty_index(tmp_path):
@@ -11,6 +11,7 @@ def test_index_folder_creates_empty_index(tmp_path):
     assert "No reports yet." in html
     assert "Index of" not in html
     assert "gitlab-allure-history" in html
+    assert 'aria-current="page">gitlab-allure-history</span>' in html
 
 
 def test_index_escapes_labels_and_encodes_links(tmp_path):
@@ -60,6 +61,40 @@ def test_index_pins_master_first(tmp_path):
 
     html = index_path.read_text(encoding="utf-8")
     assert html.index("master/") < html.index("feature/")
+
+
+def test_index_links_parent_breadcrumbs(tmp_path):
+    report_dir = tmp_path / "public" / "master" / "job_101"
+    report_dir.mkdir(parents=True)
+
+    index_path = index_folder(report_dir)
+
+    html = index_path.read_text(encoding="utf-8")
+    assert '<a href="../../">gitlab-allure-history</a>' in html
+    assert '<a href="../">master</a>' in html
+    assert 'aria-current="page">job_101</span>' in html
+
+
+def test_index_tree_updates_navigation_indexes_without_touching_reports(tmp_path):
+    public_dir = tmp_path / "public"
+    branch_dir = public_dir / "master"
+    report_dir = branch_dir / "job_101"
+    history_dir = branch_dir / "history"
+    feature_dir = public_dir / "feature"
+    report_dir.mkdir(parents=True)
+    history_dir.mkdir()
+    feature_dir.mkdir()
+    report_index = report_dir / "index.html"
+    report_index.write_text("allure report", encoding="utf-8")
+
+    index_paths = index_tree(public_dir)
+
+    assert public_dir / "index.html" in index_paths
+    assert branch_dir / "index.html" in index_paths
+    assert feature_dir / "index.html" in index_paths
+    assert report_dir / "index.html" not in index_paths
+    assert not (history_dir / "index.html").exists()
+    assert report_index.read_text(encoding="utf-8") == "allure report"
 
 
 def test_index_handles_branch_report_folder(tmp_path):


### PR DESCRIPTION
## Summary

Improve generated report index navigation by replacing plain titles with sticky breadcrumbs.

## Changes

- Render generated index titles as breadcrumb navigation.
- Link each parent breadcrumb to its corresponding parent index.
- Add recursive index regeneration for all navigation indexes in `public/`.
- Skip `job_*` and `history/` folders during recursive indexing to avoid overwriting Allure reports.
- Keep `master` pinned first in the root index.

## Validation

- `./.venv/bin/pytest -q tests/test_generate_index.py`