### PR TITLE
Use breadcrumbs as index navigation

### DIFF
--- a/generate_index.py
+++ b/generate_index.py
@@ -440,19 +440,6 @@ def breadcrumb_html(folder: Path) -> str:
     return "".join(html_parts)
 
 
-def show_parent_link(folder: Path) -> bool:
-    return folder.name != ROOT_INDEX_DIR
-
-
-def parent_row() -> list[str]:
-    return [
-        "            <tr>",
-        '                <td class="name-cell"><a href="../">../</a></td>',
-        '                <td class="modified-cell"></td>',
-        "            </tr>",
-    ]
-
-
 def entry_row(entry: Path) -> list[str]:
     return [
         "            <tr>",
@@ -476,9 +463,6 @@ def empty_row() -> list[str]:
 def build_index_html(folder: Path, entries: list[Path]) -> str:
     title = display_path(folder)
     rows: list[str] = []
-
-    if show_parent_link(folder):
-        rows.extend(parent_row())
 
     if entries:
         for entry in entries:

--- a/tests/test_generate_index.py
+++ b/tests/test_generate_index.py
@@ -75,6 +75,17 @@ def test_index_links_parent_breadcrumbs(tmp_path):
     assert 'aria-current="page">job_101</span>' in html
 
 
+def test_index_omits_parent_table_row_when_breadcrumbs_are_available(tmp_path):
+    branch_dir = tmp_path / "public" / "master"
+    (branch_dir / "job_101").mkdir(parents=True)
+
+    index_path = index_folder(branch_dir)
+
+    html = index_path.read_text(encoding="utf-8")
+    assert '<td class="name-cell"><a href="../">../</a></td>' not in html
+    assert '<a href="../">gitlab-allure-history</a>' in html
+
+
 def test_index_tree_updates_navigation_indexes_without_touching_reports(tmp_path):
     public_dir = tmp_path / "public"
     branch_dir = public_dir / "master"


### PR DESCRIPTION
## Summary

Remove the redundant `../` table row from generated indexes and rely on sticky breadcrumbs for parent navigation.

## Changes

- Drop the parent-directory row from index tables.
- Keep parent navigation available through clickable breadcrumbs.
- Add test coverage to ensure nested indexes no longer render `../` in the table.

## Validation

- `./.venv/bin/pytest -q tests/test_generate_index.py`