### PR TITLE
Make index Show more batch size configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ Required:
 
 - `GIT_PUSH_TOKEN`: token with permission to push to the repository.
 
+Optional:
+
+- `GAH_INDEX_DESKTOP_BATCH_SIZE`: number of index rows shown before `Show more...` on desktop. Defaults to `25`.
+- `GAH_INDEX_MOBILE_BATCH_SIZE`: number of index rows shown before `Show more...` on mobile. Defaults to `12`.
+
+Set either index batch size to `0` to show all rows for that viewport without progressive reveal controls.
+
 Provided by GitLab CI:
 
 - `CI_COMMIT_REF_SLUG`: used as the branch report folder.

--- a/generate_index.py
+++ b/generate_index.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 from datetime import datetime
 from html import escape
@@ -16,7 +17,9 @@ HIDDEN_INDEX_ENTRIES = {INDEX_FILENAME, MODIFIED_AT_FILENAME, HISTORY_DIRNAME}
 ROOT_INDEX_DIR = "public"
 PUBLIC_TITLE = "gitlab-allure-history"
 PINNED_ENTRY_NAMES = {"master"}
-DESKTOP_LIST_BATCH_SIZE = 20
+DESKTOP_LIST_BATCH_SIZE_ENV = "GAH_INDEX_DESKTOP_BATCH_SIZE"
+MOBILE_LIST_BATCH_SIZE_ENV = "GAH_INDEX_MOBILE_BATCH_SIZE"
+DESKTOP_LIST_BATCH_SIZE = 25
 MOBILE_LIST_BATCH_SIZE = 12
 
 STYLE = """
@@ -325,7 +328,7 @@ THEME_TOGGLE_SCRIPT = """
         })();
 """
 
-LIST_REVEAL_SCRIPT = """
+LIST_REVEAL_SCRIPT_TEMPLATE = """
         (function () {
             var table = document.querySelector("[data-progressive-list]");
 
@@ -352,15 +355,18 @@ LIST_REVEAL_SCRIPT = """
             }
 
             function updateRows(nextVisibleRows) {
-                visibleRows = Math.min(nextVisibleRows, rows.length);
+                var currentBatchSize = batchSize();
+                visibleRows = currentBatchSize <= 0 ?
+                    rows.length :
+                    Math.min(nextVisibleRows, rows.length);
 
                 rows.forEach(function (row, index) {
                     row.hidden = index >= visibleRows;
                 });
 
                 count.textContent = "Showing " + visibleRows + " of " + rows.length;
-                controls.hidden = rows.length <= batchSize();
-                button.hidden = visibleRows >= rows.length;
+                controls.hidden = currentBatchSize <= 0 || rows.length <= currentBatchSize;
+                button.hidden = currentBatchSize <= 0 || visibleRows >= rows.length;
             }
 
             button.addEventListener("click", function () {
@@ -379,11 +385,34 @@ LIST_REVEAL_SCRIPT = """
                 media.addListener(fitViewportBatch);
             }
         })();
-""".replace(
-    "__DESKTOP_BATCH_SIZE__", str(DESKTOP_LIST_BATCH_SIZE)
-).replace(
-    "__MOBILE_BATCH_SIZE__", str(MOBILE_LIST_BATCH_SIZE)
-)
+"""
+
+
+def configured_list_batch_size(env_name: str, default: int) -> int:
+    raw_value = os.environ.get(env_name)
+
+    if raw_value is None:
+        return default
+
+    try:
+        return int(raw_value.strip())
+    except ValueError:
+        return default
+
+
+def configured_list_batch_sizes() -> tuple[int, int]:
+    return (
+        configured_list_batch_size(DESKTOP_LIST_BATCH_SIZE_ENV, DESKTOP_LIST_BATCH_SIZE),
+        configured_list_batch_size(MOBILE_LIST_BATCH_SIZE_ENV, MOBILE_LIST_BATCH_SIZE),
+    )
+
+
+def list_reveal_script(desktop_batch_size: int, mobile_batch_size: int) -> str:
+    return LIST_REVEAL_SCRIPT_TEMPLATE.replace(
+        "__DESKTOP_BATCH_SIZE__", str(desktop_batch_size)
+    ).replace(
+        "__MOBILE_BATCH_SIZE__", str(mobile_batch_size)
+    )
 
 
 def job_id(entry: Path) -> int | None:
@@ -568,8 +597,12 @@ def empty_row() -> list[str]:
     ]
 
 
-def list_controls_html(entries: list[Path]) -> str:
-    if not entries:
+def list_controls_html(
+    entries: list[Path],
+    desktop_batch_size: int,
+    mobile_batch_size: int,
+) -> str:
+    if not entries or (desktop_batch_size <= 0 and mobile_batch_size <= 0):
         return ""
 
     return """
@@ -581,6 +614,7 @@ def list_controls_html(entries: list[Path]) -> str:
 
 def build_index_html(folder: Path, entries: list[Path]) -> str:
     title = display_path(folder)
+    desktop_batch_size, mobile_batch_size = configured_list_batch_sizes()
     rows: list[str] = []
 
     if entries:
@@ -621,13 +655,13 @@ def build_index_html(folder: Path, entries: list[Path]) -> str:
 {body}
             </tbody>
         </table>
-{list_controls_html(entries)}
+{list_controls_html(entries, desktop_batch_size, mobile_batch_size)}
     </main>
     <script>
 {THEME_TOGGLE_SCRIPT.rstrip()}
     </script>
     <script>
-{LIST_REVEAL_SCRIPT.rstrip()}
+{list_reveal_script(desktop_batch_size, mobile_batch_size).rstrip()}
     </script>
 </body>
 </html>

--- a/tests/test_generate_index.py
+++ b/tests/test_generate_index.py
@@ -1,6 +1,8 @@
 from generate_index import (
     DESKTOP_LIST_BATCH_SIZE,
+    DESKTOP_LIST_BATCH_SIZE_ENV,
     MOBILE_LIST_BATCH_SIZE,
+    MOBILE_LIST_BATCH_SIZE_ENV,
     index_folder,
     index_tree,
 )
@@ -143,3 +145,36 @@ def test_index_adds_show_more_controls_for_populated_lists(tmp_path):
     assert '<span class="list-count" aria-live="polite"></span>' in html
     assert '<button class="show-more" type="button">Show more...</button>' in html
     assert f"media.matches ? {MOBILE_LIST_BATCH_SIZE} : {DESKTOP_LIST_BATCH_SIZE}" in html
+
+
+def test_index_uses_configured_show_more_batch_sizes(tmp_path, monkeypatch):
+    public_dir = tmp_path / "public"
+    public_dir.mkdir()
+    monkeypatch.setenv(DESKTOP_LIST_BATCH_SIZE_ENV, "7")
+    monkeypatch.setenv(MOBILE_LIST_BATCH_SIZE_ENV, "4")
+
+    for index in range(8):
+        (public_dir / f"branch-{index:02d}").mkdir()
+
+    index_path = index_folder(public_dir)
+
+    html = index_path.read_text(encoding="utf-8")
+    assert "Show more..." in html
+    assert "media.matches ? 4 : 7" in html
+
+
+def test_index_disables_show_more_with_zero_batch_sizes(tmp_path, monkeypatch):
+    public_dir = tmp_path / "public"
+    public_dir.mkdir()
+    monkeypatch.setenv(DESKTOP_LIST_BATCH_SIZE_ENV, "0")
+    monkeypatch.setenv(MOBILE_LIST_BATCH_SIZE_ENV, "0")
+
+    for index in range(DESKTOP_LIST_BATCH_SIZE + 1):
+        (public_dir / f"branch-{index:02d}").mkdir()
+
+    index_path = index_folder(public_dir)
+
+    html = index_path.read_text(encoding="utf-8")
+    assert "Show more..." not in html
+    assert '<div class="list-controls" hidden>' not in html
+    assert html.count("<tr data-list-row>") == DESKTOP_LIST_BATCH_SIZE + 1


### PR DESCRIPTION
## Summary
- Raise the desktop Show more batch size from 20 to 25 rows.
- Add desktop and mobile environment variables for generated index batch sizes.
- Allow setting a batch size to 0 to disable progressive reveal for that viewport.

## Tests
- ./.venv/bin/pytest tests/test_generate_index.py
- ./.venv/bin/pytest -m "not demo"