### PR TITLE
Scope open demo reports by environment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,13 +1,14 @@
 image: registry.gitlab.com/aleksandr-kotlyar/gitlab-allure-history:v6
 
+variables:
+  ENV: dev
+  PAGES_BRANCH: gl-pages
+  REPORTS_TO_KEEP: "30"
+
 stages:
   - build
   - test
   - report
-
-variables:
-  PAGES_BRANCH: gl-pages
-  REPORTS_TO_KEEP: "30"
 
 build:
   image: docker:29.3.1
@@ -36,7 +37,7 @@ test_gate:
   script:
     - set -euo pipefail
     - echo "$CI_JOB_ID" > jobid
-    - pytest -m "not demo" --junitxml=report-gate.xml
+    - pytest -m "not demo" --env="$ENV" --junitxml=report-gate.xml
   artifacts:
     when: always
     expire_in: 2 hours
@@ -55,7 +56,7 @@ test_demo:
       when: always
   script:
     - set -euo pipefail
-    - pytest -m "demo" --junitxml=report-demo.xml
+    - pytest -m "demo" --env="$ENV" --junitxml=report-demo.xml
   artifacts:
     when: always
     expire_in: 2 hours
@@ -106,13 +107,15 @@ allure:
 
       JOB_ID="$(cat jobid)"
       REPORT_DIR="job_${JOB_ID}"
+      REPORT_ENV="${ENV:-dev}"
       REPORT_BRANCH="${CI_COMMIT_REF_SLUG:-detached}"
 
       PAGES_PUBLIC_DIR="pages-worktree/public"
-      BRANCH_PUBLIC_DIR="${PAGES_PUBLIC_DIR}/${REPORT_BRANCH}"
+      ENV_PUBLIC_DIR="${PAGES_PUBLIC_DIR}/${REPORT_ENV}"
+      BRANCH_PUBLIC_DIR="${ENV_PUBLIC_DIR}/${REPORT_BRANCH}"
       HISTORY_DIR="${BRANCH_PUBLIC_DIR}/history"
 
-      export JOB_ID REPORT_DIR REPORT_BRANCH
+      export JOB_ID REPORT_DIR REPORT_ENV REPORT_BRANCH
 
       mkdir -p allure-results "$BRANCH_PUBLIC_DIR"
 
@@ -120,7 +123,7 @@ allure:
         cp -r "$HISTORY_DIR" allure-results/history
         echo "Restored previous Allure history from ${HISTORY_DIR}."
       else
-        echo "No previous Allure history for branch slug '${REPORT_BRANCH}'."
+        echo "No previous Allure history for '${REPORT_ENV}/${REPORT_BRANCH}'."
       fi
 
     - |
@@ -130,6 +133,7 @@ allure:
 
       report_url = "{}/{}/{}/".format(
           os.environ["CI_PAGES_URL"].rstrip("/"),
+          os.environ["REPORT_ENV"],
           os.environ["REPORT_BRANCH"],
           os.environ["REPORT_DIR"],
       )

--- a/README.md
+++ b/README.md
@@ -66,18 +66,21 @@ Reports are persisted in the `gl-pages` branch:
 ```text
 public/
   index.html
-  <branch-slug>/
+  <env>/
     index.html
-    history/
-    job_<test-job-id>/
+    <branch-slug>/
+      index.html
+      history/
+      job_<test-job-id>/
 ```
 
-- `public/<branch-slug>/job_<test-job-id>/` is one report snapshot.
-- `public/<branch-slug>/history/` is copied into the next run to preserve Allure trends.
-- `public/index.html` lists branch folders.
-- `public/<branch-slug>/index.html` lists reports for that branch.
+- `public/<env>/<branch-slug>/job_<test-job-id>/` is one report snapshot.
+- `public/<env>/<branch-slug>/history/` is copied into the next run to preserve Allure trends.
+- `public/index.html` lists environment folders.
+- `public/<env>/index.html` lists branch folders for that environment.
+- `public/<env>/<branch-slug>/index.html` lists reports for that branch.
 
-The CI uses `CI_COMMIT_REF_SLUG` for folder names. This keeps paths safe for GitLab Pages, but it also means branch names are normalized by GitLab before they become report paths.
+The open demo pipeline uses `ENV` and `CI_COMMIT_REF_SLUG` for report folders, so the demo branch publishes to paths such as `public/dev/open-demo/`.
 
 ## Quick Start
 
@@ -139,6 +142,7 @@ Set either index batch size to `0` to show all rows for that viewport without pr
 
 Provided by GitLab CI:
 
+- `ENV`: used as the report environment folder. Defaults to `dev` in the open demo pipeline.
 - `CI_COMMIT_REF_SLUG`: used as the branch report folder.
 - `CI_JOB_ID`: used for the report snapshot folder.
 - `CI_PAGES_URL`: used in Allure executor metadata.
@@ -198,7 +202,7 @@ python3 generate_index.py public
 
 - Report history depends on a writable `gl-pages` storage branch.
 - The CI serializes the Pages publishing job with `resource_group`, but manual pushes to `gl-pages` can still race with CI.
-- `CI_COMMIT_REF_SLUG` keeps report paths safe, but different branch names can theoretically normalize to the same slug.
+- `CI_COMMIT_REF_SLUG` keeps report paths URL-safe, but different branch names can theoretically normalize to the same slug.
 - The CI keeps the latest 30 report snapshots per branch by default.
 - This template is intentionally not a reusable GitLab component, report portal, or framework.
 
@@ -220,7 +224,7 @@ The first run for a branch has no previous Allure history. The report still publ
 
 ### Pages Index Shows A Slug Instead Of The Original Branch Name
 
-This is expected. The template stores reports by `CI_COMMIT_REF_SLUG` to avoid unsafe paths in static hosting.
+This is expected. The template stores reports by `CI_COMMIT_REF_SLUG` to keep static paths URL-safe.
 
 ### Demo Tests Fail
 
@@ -230,7 +234,7 @@ This is expected. `test_demo` is marked `allow_failure: true` in GitLab CI and e
 
 Useful extensions for real projects:
 
-- keep only the last N reports per branch;
+- tune how many report snapshots are kept per branch;
 - add links from merge requests to the latest report;
 - publish only from selected branches;
 - add screenshots or videos as Allure attachments;


### PR DESCRIPTION
## Summary

- Add an `ENV` CI variable for open demo report paths.
- Publish reports under `public/<env>/<branch-slug>/`.
- Document the environment-scoped Pages layout.

## Tests

- `./.venv/bin/pytest -q -m "not demo"`
- `./.venv/bin/pytest -q tests/test_prune_reports.py`