### PR TITLE
Stabilize reusable Allure CI template

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,16 +112,33 @@ test_gate:
       - allure-results
 ```
 
-Another project can include the template from this repository:
+Another project can include the template from this repository. Pin a tag or commit SHA in real projects so CI behavior does not change unexpectedly:
 
 ```yaml
 include:
   - project: aleksandr-kotlyar/gitlab-allure-history
-    ref: master
+    ref: <pinned-tag-or-commit-sha>
     file: /templates/gitlab-allure-history.yml
+
+stages:
+  - test
+  - report
+
+test:
+  stage: test
+  image: python:3.14.5-alpine
+  script:
+    - pip install -r requirements.txt
+    - pytest --alluredir=allure-results
+  artifacts:
+    when: always
+    paths:
+      - allure-results
 ```
 
-For another project, make sure previous-stage test jobs upload `allure-results` as artifacts. The default `ALLURE_HISTORY_IMAGE` contains the report helper scripts, Java, Git, and Allure commandline. Override `ALLURE_HISTORY_IMAGE` if you want to use a project-owned image; in that case, include `generate_index.py` and `prune_reports.py` in the image at `ALLURE_HISTORY_TOOLS_DIR`.
+For another project, make sure previous-stage test jobs upload `allure-results/` as artifacts. A test job may also upload a `jobid` file containing the test job ID; when it is absent, the report job uses its own `CI_JOB_ID` for the immutable `job_<id>` snapshot folder.
+
+The default `ALLURE_HISTORY_IMAGE` contains the report helper scripts, Java, Git, Python, and Allure commandline. Override `ALLURE_HISTORY_IMAGE` if you want to use a project-owned image; in that case, include `generate_index.py` and `prune_reports.py` in the image at `ALLURE_HISTORY_TOOLS_DIR`, and provide `git`, `python3`, and the `allure` command.
 
 The template also includes a web-only `build_python` job. It runs only when the project has a `Dockerfile`, and publishes `$CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG`.
 

--- a/templates/gitlab-allure-history.yml
+++ b/templates/gitlab-allure-history.yml
@@ -22,7 +22,7 @@ build_python:
   services:
     - docker:29.3.1-dind
   variables:
-    ALLURE_HISTORY_IMAGE: $CI_COMMIT_REF_SLUG
+    IMAGE_TAG: $CI_COMMIT_REF_SLUG
   script:
     - set -euo pipefail
     - printf '%s' "$CI_REGISTRY_PASSWORD" | docker login -u "$CI_REGISTRY_USER" --password-stdin "$CI_REGISTRY"
@@ -54,9 +54,24 @@ allure:
         exit 1
       fi
 
+      if ! command -v git >/dev/null 2>&1; then
+        echo "Missing git in ALLURE_HISTORY_IMAGE (${ALLURE_HISTORY_IMAGE}). Use the default image or provide git in your custom image."
+        exit 1
+      fi
+
+      if ! command -v python3 >/dev/null 2>&1; then
+        echo "Missing python3 in ALLURE_HISTORY_IMAGE (${ALLURE_HISTORY_IMAGE}). Use the default image or provide python3 in your custom image."
+        exit 1
+      fi
+
+      if ! command -v allure >/dev/null 2>&1; then
+        echo "Missing allure command in ALLURE_HISTORY_IMAGE (${ALLURE_HISTORY_IMAGE}). Use the default image or provide Allure commandline in your custom image."
+        exit 1
+      fi
+
     - |
       if ! git clone --single-branch --branch "$PAGES_BRANCH" "$CI_REPOSITORY_URL" pages-worktree; then
-        echo "Failed to clone '${PAGES_BRANCH}'. Create the branch before publishing reports."
+        echo "Failed to clone '${PAGES_BRANCH}' from this project. Create the '${PAGES_BRANCH}' branch before publishing reports."
         exit 1
       fi
 
@@ -80,6 +95,11 @@ allure:
 
       mkdir -p allure-results "$BRANCH_PUBLIC_DIR"
 
+      if [ -z "$(find allure-results -mindepth 1 -print -quit)" ]; then
+        echo "Missing Allure results. At least one earlier job must upload allure-results/ as an artifact."
+        exit 1
+      fi
+
       if [ -d "$HISTORY_DIR" ]; then
         cp -r "$HISTORY_DIR" allure-results/history
         echo "Restored previous Allure history from ${HISTORY_DIR}."
@@ -93,7 +113,7 @@ allure:
       elif [ -f "${ALLURE_HISTORY_TOOLS_DIR}/prune_reports.py" ]; then
         PRUNE_REPORTS_PY="${ALLURE_HISTORY_TOOLS_DIR}/prune_reports.py"
       else
-        echo "Missing prune_reports.py. Provide it in ${ALLURE_HISTORY_TOOLS_DIR} through the CI image or keep it in the repository root."
+        echo "Missing prune_reports.py. Provide it in ALLURE_HISTORY_TOOLS_DIR (${ALLURE_HISTORY_TOOLS_DIR}) through the CI image or keep it in the repository root."
         exit 1
       fi
 
@@ -102,7 +122,7 @@ allure:
       elif [ -f "${ALLURE_HISTORY_TOOLS_DIR}/generate_index.py" ]; then
         GENERATE_INDEX_PY="${ALLURE_HISTORY_TOOLS_DIR}/generate_index.py"
       else
-        echo "Missing generate_index.py. Provide it in ${ALLURE_HISTORY_TOOLS_DIR} through the CI image or keep it in the repository root."
+        echo "Missing generate_index.py. Provide it in ALLURE_HISTORY_TOOLS_DIR (${ALLURE_HISTORY_TOOLS_DIR}) through the CI image or keep it in the repository root."
         exit 1
       fi
 

--- a/tests/test_gitlab_template.py
+++ b/tests/test_gitlab_template.py
@@ -30,3 +30,32 @@ def test_executor_report_url_points_to_report_snapshot(tmp_path, monkeypatch):
     executor = json.loads((tmp_path / "allure-results" / "executor.json").read_text())
 
     assert executor["reportUrl"] == "https://example.gitlab.io/project/dev/feature-login/job_123/"
+
+
+def test_project_pipeline_dogfoods_reusable_template():
+    pipeline = Path(".gitlab-ci.yml").read_text(encoding="utf-8")
+
+    assert "include:\n  - local: templates/gitlab-allure-history.yml" in pipeline
+
+
+def test_template_uses_url_safe_branch_slug_and_defined_image_tag():
+    template = Path("templates/gitlab-allure-history.yml").read_text(encoding="utf-8")
+
+    assert "IMAGE_TAG: $CI_COMMIT_REF_SLUG" in template
+    assert "ALLURE_HISTORY_IMAGE: $CI_COMMIT_REF_SLUG" not in template
+    assert "REPORT_BRANCH=\"${CI_COMMIT_REF_SLUG:-detached}\"" in template
+    assert "CI_COMMIT_REF_NAME" not in template
+
+
+def test_template_does_not_use_component_inputs():
+    template = Path("templates/gitlab-allure-history.yml").read_text(encoding="utf-8")
+
+    assert "spec:" not in template
+    assert "inputs:" not in template
+
+
+def test_readme_external_include_uses_pinned_ref_placeholder():
+    readme = Path("README.md").read_text(encoding="utf-8")
+
+    assert "project: aleksandr-kotlyar/gitlab-allure-history" in readme
+    assert "ref: <pinned-tag-or-commit-sha>" in readme


### PR DESCRIPTION
## Summary

- Fix the reusable template image build tag so `build_python` no longer references an undefined `IMAGE_TAG`.
- Add actionable validation errors for missing push token, missing tools, missing `allure-results`, missing helper scripts, and missing `gl-pages`.
- Clarify external project include usage with a pinned ref and required `allure-results` artifacts.
- Add focused tests for the reusable template contract.