### PR TITLE
Prepare reusable GitLab CI component

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,12 @@
 include:
-  - local: templates/gitlab-allure-history.yml
+  - component: $CI_SERVER_FQDN/$CI_PROJECT_PATH/gitlab-allure-history@$CI_COMMIT_TAG
+    inputs:
+      build-runtime-image: "true"
+    rules:
+      - if: $CI_COMMIT_TAG
+  - component: $CI_SERVER_FQDN/$CI_PROJECT_PATH/gitlab-allure-history@$CI_COMMIT_SHA
+    rules:
+      - if: $CI_COMMIT_TAG == null
 
 default:
   image: $ALLURE_HISTORY_IMAGE
@@ -40,3 +47,16 @@ test_demo:
     paths:
       - allure-results
       - report-demo.xml
+
+create_release:
+  stage: release
+  image: registry.gitlab.com/gitlab-org/cli:latest
+  rules:
+    - if: $CI_COMMIT_TAG
+      when: always
+    - when: never
+  script:
+    - echo "Creating release $CI_COMMIT_TAG"
+  release:
+    tag_name: $CI_COMMIT_TAG
+    description: "Release $CI_COMMIT_TAG of the gitlab-allure-history component."

--- a/README.md
+++ b/README.md
@@ -93,11 +93,18 @@ The open demo pipeline uses `ENV` and `CI_COMMIT_REF_SLUG` for report folders, s
 7. Run a pipeline on a normal branch.
 8. Open the GitLab Pages URL and navigate through the generated index.
 
-This repository dogfoods the same template with a local include:
+This repository dogfoods the component from the current commit:
 
 ```yaml
 include:
-  - local: templates/gitlab-allure-history.yml
+  - component: $CI_SERVER_FQDN/$CI_PROJECT_PATH/gitlab-allure-history@$CI_COMMIT_TAG
+    inputs:
+      build-runtime-image: "true"
+    rules:
+      - if: $CI_COMMIT_TAG
+  - component: $CI_SERVER_FQDN/$CI_PROJECT_PATH/gitlab-allure-history@$CI_COMMIT_SHA
+    rules:
+      - if: $CI_COMMIT_TAG == null
 
 default:
   image: $ALLURE_HISTORY_IMAGE
@@ -112,13 +119,15 @@ test_gate:
       - allure-results
 ```
 
-Another project can include the template from this repository. Pin a tag or commit SHA in real projects so CI behavior does not change unexpectedly:
+Another project can include the component from this repository. Pin a release tag or commit SHA in real projects so CI behavior does not change unexpectedly:
 
 ```yaml
 include:
-  - project: aleksandr-kotlyar/gitlab-allure-history
-    ref: <pinned-tag-or-commit-sha>
-    file: /templates/gitlab-allure-history.yml
+  - component: gitlab.com/aleksandr-kotlyar/gitlab-allure-history/gitlab-allure-history@<pinned-version-tag>
+    inputs:
+      environment: dev
+      pages-branch: gl-pages
+      reports-to-keep: "30"
 
 stages:
   - test
@@ -138,9 +147,9 @@ test:
 
 For another project, make sure previous-stage test jobs upload `allure-results/` as artifacts. A test job may also upload a `jobid` file containing the test job ID; when it is absent, the report job uses its own `CI_JOB_ID` for the immutable `job_<id>` snapshot folder.
 
-The default `ALLURE_HISTORY_IMAGE` contains the report helper scripts, Java, Git, Python, and Allure commandline. Override `ALLURE_HISTORY_IMAGE` if you want to use a project-owned image; in that case, include `generate_index.py` and `prune_reports.py` in the image at `ALLURE_HISTORY_TOOLS_DIR`, and provide `git`, `python3`, and the `allure` command.
+The default runtime image contains the report helper scripts, Java, Git, Python, and Allure commandline. The component appends the pinned component version to the `allure-history-image` repository input, so `@<pinned-version-tag>` uses `registry.gitlab.com/aleksandr-kotlyar/gitlab-allure-history:<pinned-version-tag>`. If you use a project-owned image repository, publish images with the same tags as the component versions, include `generate_index.py` and `prune_reports.py` in the image at `allure-history-tools-dir`, and provide `git`, `python3`, and the `allure` command.
 
-The template also includes a web-only `build_python` job. It runs only when the project has a `Dockerfile`, and publishes `$CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG`.
+The component includes an opt-in `build_python` job for this repository's release pipeline. With `build-runtime-image: "true"`, it runs only in tag pipelines and builds `$CI_REGISTRY_IMAGE:$CI_COMMIT_TAG`. This repository includes the component by `$CI_COMMIT_TAG` in tag pipelines so `$[[ component.version ]]` and the image tag are the same release value.
 
 ## Required GitLab Setup
 
@@ -176,19 +185,25 @@ Recommended settings:
 
 The token is used only by the `allure` job to push generated static content back to the `gl-pages` branch.
 
-## CI Variables And Permissions
+## Component Inputs And Permissions
 
 Required:
 
 - `GIT_PUSH_TOKEN`: token with permission to push to the repository.
 
-Optional:
+Component inputs:
 
-- `ALLURE_HISTORY_IMAGE`: CI image used by the report job. Defaults to this repository's published image.
+- `environment`: report environment folder. Defaults to `dev`.
+- `allure-history-image`: runtime image repository. Defaults to `registry.gitlab.com/aleksandr-kotlyar/gitlab-allure-history`; the pinned component version is appended as the image tag.
+- `allure-history-tools-dir`: directory inside the CI image containing `generate_index.py` and `prune_reports.py`. Defaults to `/opt/gitlab-allure-history`.
+- `pages-branch`: branch used to store generated Pages content and Allure history. Defaults to `gl-pages`.
+- `reports-to-keep`: number of report snapshots kept per environment and branch. Defaults to `30`.
+- `build-runtime-image`: build and push the runtime image in tag pipelines. Defaults to `"false"` and is intended for this repository's own release pipeline.
+
+Optional CI variables:
+
 - `ALLURE_HISTORY_INDEX_DESKTOP_BATCH_SIZE`: number of index rows shown before `Show more...` on desktop. Defaults to `25`.
 - `ALLURE_HISTORY_INDEX_MOBILE_BATCH_SIZE`: number of index rows shown before `Show more...` on mobile. Defaults to `12`.
-- `ALLURE_HISTORY_TOOLS_DIR`: directory inside the CI image containing `generate_index.py` and `prune_reports.py`. Defaults to `/opt/gitlab-allure-history`.
-- `REPORTS_TO_KEEP`: number of report snapshots kept per environment and branch. Defaults to `30`.
 
 Set either index batch size to `0` to show all rows for that viewport without progressive reveal controls.
 
@@ -251,13 +266,26 @@ python3 generate_index.py public
 - GitLab mirror: [gitlab.com/aleksandr-kotlyar/gitlab-allure-history](https://gitlab.com/aleksandr-kotlyar/gitlab-allure-history)
 - Pages report: [aleksandr-kotlyar.gitlab.io/gitlab-allure-history](https://aleksandr-kotlyar.gitlab.io/gitlab-allure-history/)
 
+## Pinned Version Usage
+
+Use an immutable component version in application projects:
+
+```yaml
+include:
+  - component: gitlab.com/aleksandr-kotlyar/gitlab-allure-history/gitlab-allure-history@<pinned-version-tag>
+```
+
+Prefer a release tag for normal use, or a full commit SHA when you need maximum immutability. Avoid moving references such as branches or `~latest` for production pipelines because they can change CI behavior without a merge request in the consuming project.
+
+Component release tags also version the default runtime image. When a tag pipeline runs in this repository, it builds and pushes the same tag to the container registry and creates a GitLab release for the component.
+
 ## Limitations And Trade-Offs
 
 - Report history depends on a writable `gl-pages` storage branch.
 - The CI serializes the Pages publishing job with `resource_group`, but manual pushes to `gl-pages` can still race with CI.
 - `CI_COMMIT_REF_SLUG` keeps report paths URL-safe, but different branch names can theoretically normalize to the same slug.
 - The CI keeps the latest 30 report snapshots per branch by default.
-- This template is intentionally not a packaged GitLab CI/CD component, report portal, or framework.
+- This project is a GitLab CI/CD component, not a report portal or framework.
 
 ## Troubleshooting
 

--- a/templates/gitlab-allure-history.yml
+++ b/templates/gitlab-allure-history.yml
@@ -1,20 +1,47 @@
+spec:
+  component: [version]
+  inputs:
+    environment:
+      default: dev
+      description: Report environment folder under public/.
+    allure-history-image:
+      default: registry.gitlab.com/aleksandr-kotlyar/gitlab-allure-history
+      description: Runtime image repository. The component version is appended as the image tag.
+    allure-history-tools-dir:
+      default: /opt/gitlab-allure-history
+      description: Directory in the runtime image containing generate_index.py and prune_reports.py.
+    pages-branch:
+      default: gl-pages
+      description: Branch used to store generated Pages content and Allure history.
+    reports-to-keep:
+      default: "30"
+      description: Number of report snapshots kept per environment and branch.
+    build-runtime-image:
+      default: "false"
+      options:
+        - "true"
+        - "false"
+      description: Build and push this project's tagged runtime image before tests in tag pipelines.
+---
+
 variables:
-  ENV: dev
-  ALLURE_HISTORY_IMAGE: registry.gitlab.com/aleksandr-kotlyar/gitlab-allure-history:2026.2.1
-  ALLURE_HISTORY_TOOLS_DIR: /opt/gitlab-allure-history
-  PAGES_BRANCH: gl-pages
-  REPORTS_TO_KEEP: "30"
+  ENV: $[[ inputs.environment ]]
+  ALLURE_HISTORY_IMAGE: $[[ inputs.allure-history-image ]]:$[[ component.version ]]
+  ALLURE_HISTORY_TOOLS_DIR: $[[ inputs.allure-history-tools-dir ]]
+  PAGES_BRANCH: $[[ inputs.pages-branch ]]
+  REPORTS_TO_KEEP: $[[ inputs.reports-to-keep ]]
 
 stages:
   - build
   - test
   - report
+  - release
 
 build_python:
   image: docker:29.3.1
   stage: build
   rules:
-    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: '"$[[ inputs.build-runtime-image ]]" == "true" && $CI_COMMIT_TAG'
       exists:
         - Dockerfile
       when: always
@@ -22,7 +49,7 @@ build_python:
   services:
     - docker:29.3.1-dind
   variables:
-    IMAGE_TAG: $CI_COMMIT_REF_SLUG
+    IMAGE_TAG: $CI_COMMIT_TAG
   script:
     - set -euo pipefail
     - printf '%s' "$CI_REGISTRY_PASSWORD" | docker login -u "$CI_REGISTRY_USER" --password-stdin "$CI_REGISTRY"

--- a/tests/test_gitlab_template.py
+++ b/tests/test_gitlab_template.py
@@ -35,27 +35,56 @@ def test_executor_report_url_points_to_report_snapshot(tmp_path, monkeypatch):
 def test_project_pipeline_dogfoods_reusable_template():
     pipeline = Path(".gitlab-ci.yml").read_text(encoding="utf-8")
 
-    assert "include:\n  - local: templates/gitlab-allure-history.yml" in pipeline
+    assert (
+        "include:\n"
+        "  - component: $CI_SERVER_FQDN/$CI_PROJECT_PATH/gitlab-allure-history@$CI_COMMIT_TAG"
+        in pipeline
+    )
+    assert 'build-runtime-image: "true"' in pipeline
+    assert "  - component: $CI_SERVER_FQDN/$CI_PROJECT_PATH/gitlab-allure-history@$CI_COMMIT_SHA" in pipeline
+    assert "if: $CI_COMMIT_TAG == null" in pipeline
+    assert "create_release:" in pipeline
+    assert "tag_name: $CI_COMMIT_TAG" in pipeline
 
 
-def test_template_uses_url_safe_branch_slug_and_defined_image_tag():
+def test_template_uses_url_safe_branch_slug_and_component_versioned_image_tag():
     template = Path("templates/gitlab-allure-history.yml").read_text(encoding="utf-8")
 
-    assert "IMAGE_TAG: $CI_COMMIT_REF_SLUG" in template
+    assert '"$[[ inputs.build-runtime-image ]]" == "true" && $CI_COMMIT_TAG' in template
+    assert "IMAGE_TAG: $CI_COMMIT_TAG" in template
+    assert (
+        "ALLURE_HISTORY_IMAGE: $[[ inputs.allure-history-image ]]:$[[ component.version ]]"
+        in template
+    )
+    assert "docker build -t \"$CI_REGISTRY_IMAGE:$IMAGE_TAG\" ." in template
+    assert "docker push \"$CI_REGISTRY_IMAGE:$IMAGE_TAG\"" in template
+    assert "docker tag \"$CI_REGISTRY_IMAGE:$IMAGE_TAG\"" not in template
+    assert "IMAGE_TAG: $CI_COMMIT_SHA" not in template
     assert "ALLURE_HISTORY_IMAGE: $CI_COMMIT_REF_SLUG" not in template
     assert "REPORT_BRANCH=\"${CI_COMMIT_REF_SLUG:-detached}\"" in template
     assert "CI_COMMIT_REF_NAME" not in template
 
 
-def test_template_does_not_use_component_inputs():
+def test_template_defines_component_inputs():
     template = Path("templates/gitlab-allure-history.yml").read_text(encoding="utf-8")
 
-    assert "spec:" not in template
-    assert "inputs:" not in template
+    assert template.startswith("spec:\n")
+    assert "  component: [version]\n" in template
+    assert "  inputs:\n" in template
+    assert "    environment:\n" in template
+    assert "    allure-history-image:\n" in template
+    assert "    pages-branch:\n" in template
+    assert "    reports-to-keep:\n" in template
+    assert "    build-runtime-image:\n" in template
+    assert "---\n\nvariables:" in template
 
 
-def test_readme_external_include_uses_pinned_ref_placeholder():
+def test_readme_external_include_uses_pinned_component_version():
     readme = Path("README.md").read_text(encoding="utf-8")
 
-    assert "project: aleksandr-kotlyar/gitlab-allure-history" in readme
-    assert "ref: <pinned-tag-or-commit-sha>" in readme
+    assert (
+        "component: gitlab.com/aleksandr-kotlyar/gitlab-allure-history/"
+        "gitlab-allure-history@<pinned-version-tag>"
+        in readme
+    )
+    assert "Avoid moving references such as branches or `~latest`" in readme


### PR DESCRIPTION
## Summary

- Convert the Allure history template into a GitLab CI/CD component with `spec:inputs`.
- Version the default runtime image from the pinned component version.
- Build and push the runtime image only in tag pipelines as `$CI_REGISTRY_IMAGE:$CI_COMMIT_TAG`.
- Add a tag release job so component tags publish GitLab releases.
- Document pinned component usage and update template tests.