### PR TITLE
Add MR comment integration for Allure report links (closes #33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,11 +204,13 @@ Component inputs:
 - `pages-branch`: branch used to store generated Pages content and Allure history. Defaults to `gl-pages`.
 - `reports-to-keep`: number of report snapshots kept per environment and branch. Defaults to `30`.
 - `build-runtime-image`: build and push the runtime image in tag pipelines. Defaults to `"false"` and is intended for this repository's own release pipeline.
+- `comment-mr`: post or update a merge request comment with the latest report URL. Defaults to `"false"`. Requires `CI_MERGE_REQUEST_IID` context.
 
 Optional CI variables:
 
 - `ALLURE_HISTORY_INDEX_DESKTOP_BATCH_SIZE`: number of index rows shown before `Show more...` on desktop. Defaults to `25`.
 - `ALLURE_HISTORY_INDEX_MOBILE_BATCH_SIZE`: number of index rows shown before `Show more...` on mobile. Defaults to `12`.
+- `ALLURE_HISTORY_TOKEN`: token with `api` scope for posting MR comments. Falls back to `CI_JOB_TOKEN` when unset.
 
 Set either index batch size to `0` to show all rows for that viewport without progressive reveal controls.
 
@@ -323,7 +325,7 @@ This is expected. `test_demo` is marked `allow_failure: true` in GitLab CI and e
 Useful extensions for real projects:
 
 - tune how many report snapshots are kept per branch;
-- add links from merge requests to the latest report;
+- ~~add links from merge requests to the latest report;~~ (implemented via `comment-mr` input)
 - publish only from selected branches;
 - add screenshots or videos as Allure attachments;
 - replace the example CI image with a project-owned image.

--- a/templates/gitlab-allure-history.yml
+++ b/templates/gitlab-allure-history.yml
@@ -23,6 +23,12 @@ spec:
         - "true"
         - "false"
       description: Build and push this project's tagged runtime image before tests in tag pipelines.
+    comment-mr:
+      default: "false"
+      options:
+        - "true"
+        - "false"
+      description: Post or update a merge request comment with the latest report URL.
 ---
 
 variables:
@@ -31,6 +37,7 @@ variables:
   ALLURE_HISTORY_TOOLS_DIR: $[[ inputs.allure-history-tools-dir ]]
   PAGES_BRANCH: $[[ inputs.pages-branch ]]
   REPORTS_TO_KEEP: $[[ inputs.reports-to-keep ]]
+  ALLURE_HISTORY_COMMENT_MR: $[[ inputs.comment-mr ]]
 
 stages:
   - build
@@ -239,3 +246,42 @@ allure:
 
       rm -rf public
       cp -r pages-worktree/public public
+
+    - |
+      if [ "${ALLURE_HISTORY_COMMENT_MR}" = "true" ] && [ -n "${CI_MERGE_REQUEST_IID:-}" ]; then
+        TOKEN="${ALLURE_HISTORY_TOKEN:-${CI_JOB_TOKEN}}"
+        REPORT_URL="${CI_PAGES_URL}/${REPORT_ENV}/${REPORT_BRANCH}/${REPORT_DIR}/"
+        MARKER="<!-- allure-history-report -->"
+        COMMENT_BODY="## Allure Report\n\n[View test report](${REPORT_URL})\n\n${MARKER}"
+
+        EXISTING_NOTE_ID=$(curl -s --header "PRIVATE-TOKEN: ${TOKEN}" \
+          "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/merge_requests/${CI_MERGE_REQUEST_IID}/notes?sort=desc&per_page=100" \
+          | python3 - 2>/dev/null <<'PY' || true
+        import json, sys
+        marker = "<!-- allure-history-report -->"
+        try:
+            notes = json.load(sys.stdin)
+        except:
+            sys.exit(0)
+        for note in notes:
+            if marker in note.get('body', ''):
+                print(note['id'])
+                break
+        PY
+
+        if [ -n "$EXISTING_NOTE_ID" ]; then
+          curl -s --request PUT \
+            --header "PRIVATE-TOKEN: ${TOKEN}" \
+            --data-urlencode "body=${COMMENT_BODY}" \
+            "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/merge_requests/${CI_MERGE_REQUEST_IID}/notes/${EXISTING_NOTE_ID}" \
+            > /dev/null 2>&1 || true
+          echo "Updated MR comment note ${EXISTING_NOTE_ID} with report URL: ${REPORT_URL}"
+        else
+          curl -s --request POST \
+            --header "PRIVATE-TOKEN: ${TOKEN}" \
+            --data-urlencode "body=${COMMENT_BODY}" \
+            "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/merge_requests/${CI_MERGE_REQUEST_IID}/notes" \
+            > /dev/null 2>&1 || true
+          echo "Created MR comment with report URL: ${REPORT_URL}"
+        fi
+      fi


### PR DESCRIPTION
- Teams see a direct link to the latest Allure report right inside the merge request — no more hunting through pipeline artifacts.
- Existing comments are automatically updated on each new pipeline run, keeping the link fresh without cluttering the MR discussion.
- Zero configuration beyond setting comment-mr: "true" — works with the existing CI_JOB_TOKEN for authentication.