### PR TITLE
Add automated smoke checks for published Pages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -115,6 +115,28 @@ allure:
   tags:
     - macos-local
 
+pages_smoke:
+  stage: release
+  needs:
+    - job: test_gate
+      artifacts: true
+    - job: allure
+      artifacts: false
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "web"
+      when: never
+    - when: always
+  script:
+    - set -euo pipefail
+    - test -s jobid
+    - python3 smoke_public_pages.py
+        --base-url "$CI_PAGES_URL"
+        --environment "$ENV"
+        --branch "$CI_COMMIT_REF_SLUG"
+        --report "job_$(cat jobid)"
+  tags:
+    - macos-local
+
 create_release:
   stage: release
   image: registry.gitlab.com/gitlab-org/cli:latest

--- a/smoke_public_pages.py
+++ b/smoke_public_pages.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from collections.abc import Callable
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+DEFAULT_ATTEMPTS = 12
+DEFAULT_DELAY_SECONDS = 5.0
+USER_AGENT = "gitlab-allure-history-pages-smoke"
+
+
+def public_page_urls(base_url: str, environment: str, branch: str, report: str):
+    base_url = base_url.rstrip("/")
+    path_parts = [quote(part, safe="") for part in (environment, branch)]
+    environment_url = f"{base_url}/{path_parts[0]}/"
+    branch_url = f"{environment_url}{path_parts[1]}/"
+
+    return (
+        environment_url,
+        branch_url,
+        f"{branch_url}latest/",
+        f"{branch_url}{quote(report, safe='')}/",
+    )
+
+
+def fetch_page(url: str) -> tuple[int, str]:
+    request = Request(url, headers={"User-Agent": USER_AGENT})
+
+    with urlopen(request, timeout=15) as response:
+        status = response.status
+        final_url = response.geturl()
+        response.read(1)
+
+    return status, final_url
+
+
+def wait_for_public_pages(
+    urls: tuple[str, ...],
+    attempts: int = DEFAULT_ATTEMPTS,
+    delay_seconds: float = DEFAULT_DELAY_SECONDS,
+    fetch: Callable[[str], tuple[int, str]] = fetch_page,
+    sleep: Callable[[float], None] = time.sleep,
+) -> None:
+    failures = {}
+
+    for attempt in range(1, attempts + 1):
+        failures = {}
+
+        for url in urls:
+            try:
+                status, final_url = fetch(url)
+                if not 200 <= status < 300:
+                    failures[url] = f"HTTP {status}"
+                else:
+                    print(f"OK {url} -> {final_url} ({status})")
+            except (HTTPError, URLError, TimeoutError, OSError) as error:
+                failures[url] = str(error)
+
+        if not failures:
+            return
+
+        details = "; ".join(f"{url}: {error}" for url, error in failures.items())
+        print(f"Attempt {attempt}/{attempts} failed: {details}", file=sys.stderr)
+
+        if attempt < attempts:
+            sleep(delay_seconds)
+
+    raise RuntimeError(
+        "Public Pages smoke failed: "
+        + "; ".join(f"{url}: {error}" for url, error in failures.items())
+    )
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Verify published GitLab Pages navigation and report URLs."
+    )
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--environment", required=True)
+    parser.add_argument("--branch", required=True)
+    parser.add_argument("--report", required=True)
+    parser.add_argument("--attempts", type=int, default=DEFAULT_ATTEMPTS)
+    parser.add_argument("--delay-seconds", type=float, default=DEFAULT_DELAY_SECONDS)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+
+    if args.attempts < 1 or args.delay_seconds < 0:
+        raise SystemExit("--attempts must be positive and --delay-seconds non-negative")
+
+    urls = public_page_urls(
+        args.base_url,
+        args.environment,
+        args.branch,
+        args.report,
+    )
+    wait_for_public_pages(
+        urls,
+        attempts=args.attempts,
+        delay_seconds=args.delay_seconds,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gitlab_template.py
+++ b/tests/test_gitlab_template.py
@@ -91,6 +91,18 @@ def test_project_pipeline_dogfoods_reusable_template():
     assert "tag_name: $CI_COMMIT_TAG" in pipeline
 
 
+def test_project_pipeline_smokes_published_pages_after_allure():
+    pipeline = Path(".gitlab-ci.yml").read_text(encoding="utf-8")
+
+    assert "pages_smoke:\n  stage: release\n" in pipeline
+    assert "    - job: test_gate\n      artifacts: true" in pipeline
+    assert "    - job: allure\n      artifacts: false" in pipeline
+    assert '        --base-url "$CI_PAGES_URL"' in pipeline
+    assert '        --environment "$ENV"' in pipeline
+    assert '        --branch "$CI_COMMIT_REF_SLUG"' in pipeline
+    assert '        --report "job_$(cat jobid)"' in pipeline
+
+
 def test_template_uses_url_safe_branch_slug_and_component_versioned_image_tag():
     template = Path("templates/gitlab-allure-history.yml").read_text(encoding="utf-8")
 

--- a/tests/test_smoke_public_pages.py
+++ b/tests/test_smoke_public_pages.py
@@ -1,0 +1,54 @@
+from urllib.error import HTTPError
+
+import pytest
+
+from smoke_public_pages import public_page_urls, wait_for_public_pages
+
+
+def test_public_page_urls_cover_environment_branch_latest_and_fresh_report():
+    assert public_page_urls(
+        "https://example.gitlab.io/project/",
+        "dev",
+        "feature login",
+        "job_123",
+    ) == (
+        "https://example.gitlab.io/project/dev/",
+        "https://example.gitlab.io/project/dev/feature%20login/",
+        "https://example.gitlab.io/project/dev/feature%20login/latest/",
+        "https://example.gitlab.io/project/dev/feature%20login/job_123/",
+    )
+
+
+def test_wait_for_public_pages_retries_until_every_url_is_available():
+    urls = ("https://example.test/dev/", "https://example.test/dev/master/latest/")
+    calls = []
+    sleeps = []
+
+    def fetch(url):
+        calls.append(url)
+        if len(calls) <= len(urls):
+            raise HTTPError(url, 404, "Not Found", {}, None)
+        return 200, url
+
+    wait_for_public_pages(
+        urls,
+        attempts=2,
+        delay_seconds=3,
+        fetch=fetch,
+        sleep=sleeps.append,
+    )
+
+    assert calls == [*urls, *urls]
+    assert sleeps == [3]
+
+
+def test_wait_for_public_pages_reports_unavailable_urls():
+    url = "https://example.test/dev/master/job_123/"
+
+    with pytest.raises(RuntimeError, match="job_123"):
+        wait_for_public_pages(
+            (url,),
+            attempts=1,
+            delay_seconds=0,
+            fetch=lambda requested_url: (503, requested_url),
+        )


### PR DESCRIPTION
- Check environment, branch, latest, and fresh report URLs.
- Retry while the Pages deployment becomes available.
- Run smoke automation after successful report publication.