### PR TITLE
Add GitHub and GitLab issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,121 @@
+name: Bug report
+description: Report a reproducible defect in the component.
+title: "[Bug] "
+body:
+  - type: dropdown
+    id: affected-area
+    attributes:
+      label: Affected area
+      options:
+        - Component include
+        - Report publishing
+        - GitLab Pages
+        - latest/ alias
+        - Index generation
+        - MR comment
+        - Pruning/history
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: component-ref
+    attributes:
+      label: Component version or ref
+      description: Tag, branch, commit SHA, or overridden image tag.
+      placeholder: "2026.2.7"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: gitlab-environment
+    attributes:
+      label: GitLab environment
+      options:
+        - GitLab.com
+        - Self-managed
+    validations:
+      required: true
+
+  - type: input
+    id: self-managed-version
+    attributes:
+      label: Self-managed GitLab version
+      description: Leave blank for GitLab.com.
+      placeholder: "18.1.0"
+
+  - type: input
+    id: runner
+    attributes:
+      label: Runner executor and image
+      description: Include runner version when relevant.
+      placeholder: "GitLab Runner 18.1, Docker executor, python:3.13"
+
+  - type: textarea
+    id: include-snippet
+    attributes:
+      label: Sanitized component include
+      description: Paste the minimal relevant part of `.gitlab-ci.yml`. Do not paste secrets.
+      render: yaml
+    validations:
+      required: true
+
+  - type: textarea
+    id: ci-variables
+    attributes:
+      label: Relevant CI variables
+      description: List variable names, relevant settings, and non-secret values only. Do not paste token values.
+      placeholder: |
+        GIT_PUSH_TOKEN: configured, masked, protected
+        ENV: dev
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Provide the smallest reliable sequence that reproduces the issue.
+    validations:
+      required: true
+
+  - type: textarea
+    id: job-log
+    attributes:
+      label: Pipeline/job link or sanitized log excerpt
+      description: Include the failing job name. Remove tokens, credentials, and private URLs.
+      render: shell
+    validations:
+      required: true
+
+  - type: input
+    id: report-url
+    attributes:
+      label: Pages or report URL
+      description: Provide it when relevant; sanitize private hostnames if needed.
+
+  - type: dropdown
+    id: latest-release
+    attributes:
+      label: Does this reproduce on the latest release?
+      options:
+        - "Yes"
+        - "No"
+        - Not tested
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,84 @@
+name: Feature request
+description: Propose a focused improvement to the static report publisher.
+title: "[Feature] "
+body:
+  - type: markdown
+    attributes:
+      value: >
+        This project should remain a static GitLab Pages publisher. Requests
+        for a backend, database, dashboard platform, analytics service, or test
+        management system are out of scope unless clearly justified as
+        static-output features.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: Describe the limitation and who encounters it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-behavior
+    attributes:
+      label: Proposed behavior
+      description: Describe the observable result, not only an implementation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: workaround
+    attributes:
+      label: Current workaround
+      description: Write "None" if no practical workaround exists.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: affected-workflow
+    attributes:
+      label: Affected workflow
+      options:
+        - Report publishing
+        - latest/ links
+        - Storage layout
+        - MR comments
+        - Component inputs
+        - Docs/troubleshooting
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: storage-layout-impact
+    attributes:
+      label: Storage or layout impact
+      description: Explain changes to static files, URLs, history, or retention. Write "None" if unaffected.
+    validations:
+      required: true
+
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility concerns
+      description: Note effects on existing inputs, URLs, stored reports, or pipelines.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: static-pages-fit
+    attributes:
+      label: Does this fit the static GitLab Pages model?
+      options:
+        - "Yes"
+        - Unsure
+        - "No"
+    validations:
+      required: true
+
+  - type: textarea
+    id: examples
+    attributes:
+      label: Desired configuration or output
+      description: Add a concise example when it clarifies the request.
+      render: yaml

--- a/.github/ISSUE_TEMPLATE/integration_help.yml
+++ b/.github/ISSUE_TEMPLATE/integration_help.yml
@@ -1,0 +1,125 @@
+name: Integration help
+description: Diagnose component setup, CI, token, artifact, or Pages problems.
+title: "[Integration] "
+body:
+  - type: textarea
+    id: integration-goal
+    attributes:
+      label: Integration goal
+      description: What are you trying to publish, and from which jobs or pipelines?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: gitlab-environment
+    attributes:
+      label: GitLab environment
+      options:
+        - GitLab.com
+        - Self-managed
+    validations:
+      required: true
+
+  - type: input
+    id: self-managed-version
+    attributes:
+      label: Self-managed GitLab version
+      description: Leave blank for GitLab.com.
+
+  - type: dropdown
+    id: project-visibility
+    attributes:
+      label: Project visibility
+      options:
+        - Public
+        - Internal
+        - Private
+    validations:
+      required: true
+
+  - type: dropdown
+    id: pipeline-source
+    attributes:
+      label: Pipeline source
+      options:
+        - push
+        - merge_request_event
+        - schedule
+        - tag
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: include-snippet
+    attributes:
+      label: Sanitized component include
+      description: Paste the relevant `.gitlab-ci.yml` include. Do not paste secrets.
+      render: yaml
+    validations:
+      required: true
+
+  - type: textarea
+    id: configured-inputs
+    attributes:
+      label: Configured inputs
+      description: Include environment, pages-branch, reports-to-keep, comment-mr, and image/image-tag overrides.
+      render: yaml
+    validations:
+      required: true
+
+  - type: textarea
+    id: allure-results
+    attributes:
+      label: allure-results and artifacts
+      description: State where `allure-results` is produced and whether its artifact exists before the publish job starts.
+    validations:
+      required: true
+
+  - type: textarea
+    id: token
+    attributes:
+      label: Token type and scopes
+      description: Include the token type and scopes only. Do not paste the token value.
+      placeholder: "Project access token with write_repository"
+    validations:
+      required: true
+
+  - type: textarea
+    id: variable-availability
+    attributes:
+      label: CI variable availability
+      description: State whether relevant variables are protected/masked and available to this pipeline source.
+    validations:
+      required: true
+
+  - type: textarea
+    id: pages-settings
+    attributes:
+      label: Pages branch and settings
+      description: Include branch protection and Pages settings if known. Write "Unknown" if unavailable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: failing-job
+    attributes:
+      label: Failing job and sanitized log excerpt
+      description: Name the exact job and remove tokens, credentials, and private URLs.
+      render: shell
+    validations:
+      required: true
+
+  - type: input
+    id: expected-url
+    attributes:
+      label: Expected Pages or report URL
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-result
+    attributes:
+      label: Actual URL or error
+    validations:
+      required: true

--- a/.gitlab/issue_templates/Bug report.md
+++ b/.gitlab/issue_templates/Bug report.md
@@ -1,0 +1,60 @@
+# Bug report
+
+## Affected area
+
+<!-- Choose one: component include, report publishing, GitLab Pages,
+latest/ alias, index generation, MR comment, pruning/history,
+documentation, other. -->
+
+## Component version or ref
+
+<!-- Tag, branch, commit SHA, or overridden image tag. -->
+
+## GitLab environment
+
+<!-- GitLab.com or self-managed. Include the self-managed version. -->
+
+## Runner
+
+<!-- Executor, image, and runner version when relevant. -->
+
+## Sanitized component include
+
+<!-- Paste the minimal relevant part of .gitlab-ci.yml. Do not paste secrets. -->
+
+```yaml
+
+```
+
+## Relevant CI variables
+
+<!-- List variable names, relevant settings, and non-secret values only.
+Do not paste token values. -->
+
+```text
+
+```
+
+## Expected behavior
+
+## Actual behavior
+
+## Reproduction steps
+
+1.
+
+## Pipeline/job link or sanitized log excerpt
+
+<!-- Include the failing job name. Remove tokens, credentials, and private URLs. -->
+
+```text
+
+```
+
+## Pages or report URL
+
+<!-- Provide it when relevant; sanitize private hostnames if needed. -->
+
+## Latest release
+
+<!-- Does this reproduce on the latest release? Yes / No / Not tested. -->

--- a/.gitlab/issue_templates/Feature request.md
+++ b/.gitlab/issue_templates/Feature request.md
@@ -1,0 +1,44 @@
+# Feature request
+
+> This project should remain a static GitLab Pages publisher. Requests
+> for a backend, database, dashboard platform, analytics service, or test
+> management system are out of scope unless clearly justified as
+> static-output features.
+
+## Problem or use case
+
+<!-- Describe the limitation, who encounters it, and the affected scenario. -->
+
+## Proposed behavior
+
+<!-- Describe the observable result, not only an implementation. -->
+
+## Current workaround
+
+<!-- Write "None" if no practical workaround exists. -->
+
+## Affected workflow
+
+<!-- Choose one: report publishing, latest/ links, storage layout,
+MR comments, component inputs, docs/troubleshooting, other. -->
+
+## Storage or layout impact
+
+<!-- Explain changes to static files, URLs, history, or retention.
+Write "None" if unaffected. -->
+
+## Compatibility concerns
+
+<!-- Note effects on existing inputs, URLs, stored reports, or pipelines. -->
+
+## Static GitLab Pages fit
+
+<!-- Does this fit the static GitLab Pages model? Yes / No / Unsure. -->
+
+## Desired configuration or output
+
+<!-- Add a concise example when it clarifies the request. -->
+
+```yaml
+
+```

--- a/.gitlab/issue_templates/Integration help.md
+++ b/.gitlab/issue_templates/Integration help.md
@@ -1,0 +1,65 @@
+# Integration help
+
+## Integration goal
+
+<!-- What are you trying to publish, and from which jobs or pipelines? -->
+
+## GitLab environment
+
+<!-- GitLab.com or self-managed. Include the self-managed version. -->
+
+## Project visibility
+
+<!-- Public / Internal / Private. -->
+
+## Pipeline source
+
+<!-- push / merge_request_event / schedule / tag / other. -->
+
+## Sanitized component include
+
+<!-- Paste the relevant .gitlab-ci.yml include. Do not paste secrets. -->
+
+```yaml
+
+```
+
+## Configured inputs
+
+<!-- Include environment, pages-branch, reports-to-keep, comment-mr,
+and image/image-tag overrides. -->
+
+```yaml
+
+```
+
+## allure-results and artifacts
+
+<!-- Where is allure-results produced? Does its artifact exist before
+the publish job starts? -->
+
+## Token type and scopes
+
+<!-- Include the token type and scopes only. Do not paste the token value. -->
+
+## CI variable availability
+
+<!-- Are relevant variables protected/masked and available to this
+pipeline source? -->
+
+## Pages branch and settings
+
+<!-- Include branch protection and Pages settings if known.
+Write "Unknown" if unavailable. -->
+
+## Failing job and sanitized log excerpt
+
+<!-- Name the exact job. Remove tokens, credentials, and private URLs. -->
+
+```text
+
+```
+
+## Expected Pages or report URL
+
+## Actual URL or error


### PR DESCRIPTION
- Add bug report, feature request, and integration help templates for GitHub and GitLab.
- Require actionable CI, component, token scope, artifact, and Pages context without secrets.
- Disable blank GitHub issues and keep feature requests within the static Pages publisher scope.