### PR TITLE
Add default GitLab issue template selector

### DIFF
--- a/.gitlab/issue_templates/Default.md
+++ b/.gitlab/issue_templates/Default.md
@@ -1,0 +1,9 @@
+# Choose an issue template
+
+Select the template that matches your request:
+
+- [Bug report](/aleksandr-kotlyar/gitlab-allure-history/-/issues/new?description_template=Bug%20report) for a reproducible defect in the component.
+- [Feature request](/aleksandr-kotlyar/gitlab-allure-history/-/issues/new?description_template=Feature%20request) for a focused improvement to the static publisher.
+- [Integration help](/aleksandr-kotlyar/gitlab-allure-history/-/issues/new?description_template=Integration%20help) for CI, token, artifact, or GitLab Pages setup problems.
+
+<!-- Apply one of the templates above before creating the issue. -->


### PR DESCRIPTION
- Add Default.md as the default GitLab issue description.
- Link directly to Bug report, Feature request, and Integration help templates.
- Guide users to the appropriate structured template before submission.