### PR TITLE
docs: split user and maintainer documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,315 @@
+# Contributing
+
+Thanks for your interest in improving `gitlab-allure-history`.
+
+This project is a lightweight GitLab CI component for publishing branch-based Allure report history to GitLab Pages.
+
+The main goal is to stay small, static, and GitLab-native.
+
+## Scope
+
+Good contributions:
+
+* improve GitLab CI component usability;
+* improve generated static index pages;
+* improve Allure report history preservation;
+* improve `latest/` report aliases;
+* improve merge request report comments;
+* improve documentation and examples;
+* improve tests for generated HTML, pruning, and component behavior;
+* fix bugs in report publishing, history reuse, or index generation.
+
+Out of scope:
+
+* backend services;
+* databases;
+* custom report portal features;
+* replacing Allure UI;
+* test management functionality;
+* analytics dashboards;
+* frontend frameworks;
+* authentication/authorization layers;
+* long-running infrastructure outside GitLab CI and GitLab Pages.
+
+This project should remain a static report publisher, not a mini ReportPortal.
+
+## Development Setup
+
+Create a virtual environment:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Run tests:
+
+```bash
+pytest
+```
+
+Run only non-demo tests:
+
+```bash
+pytest -m "not demo"
+```
+
+Run demo tests:
+
+```bash
+pytest -m "demo"
+```
+
+Demo tests may intentionally produce non-green Allure states. They exist to generate meaningful example reports.
+
+## Testing Generated Indexes
+
+The generated index pages are part of the product.
+
+When changing `generate_index.py`, check that generated indexes still work for:
+
+* root index;
+* environment index;
+* branch/report index;
+* report rows with passed results;
+* report rows with issues;
+* `latest/` aliases;
+* hidden/internal folders;
+* light and dark themes if affected.
+
+Important internal entries must not appear as normal rows:
+
+```text
+history/
+latest/
+index.html
+.modified_at
+```
+
+Expected branch report layout:
+
+```text
+public/
+  dev/
+    master/
+      index.html
+      latest/
+        index.html
+      history/
+      job_NNN/
+      job_NNN/
+```
+
+`latest/` must be a lightweight redirect alias to the newest immutable `job_NNN/` report. It must not copy the full report.
+
+## Testing Latest Report Aliases
+
+When changing latest report logic, verify:
+
+* `latest/index.html` is generated for folders containing report snapshots;
+* `latest/index.html` redirects to the newest `job_NNN/`;
+* `latest/` moves when a newer report appears;
+* `latest/` is not listed as a report row;
+* parent indexes link to stable `latest/` aliases;
+* old immutable `job_NNN/` URLs remain valid;
+* pruning does not delete `latest/` or `history/`.
+
+## Testing Pruning
+
+When changing `prune_reports.py`, verify:
+
+* only old `job_*` report folders are removed;
+* `history/` is preserved;
+* `latest/` is preserved;
+* `index.html` is preserved;
+* `.modified_at` is preserved;
+* report retention remains predictable.
+
+Pruning must never delete Allure history data needed by the next run.
+
+## Testing Merge Request Comments
+
+Merge request comments are optional.
+
+They must not break report publishing.
+
+Token responsibilities:
+
+```text
+GIT_PUSH_TOKEN
+  used only for git operations against the Pages storage branch
+
+ALLURE_HISTORY_TOKEN
+  used only for GitLab REST API calls, such as MR comments
+```
+
+When changing MR comment logic, verify:
+
+* `GIT_PUSH_TOKEN` is not used for GitLab API calls;
+* `ALLURE_HISTORY_TOKEN` is used for creating/updating MR comments;
+* missing `ALLURE_HISTORY_TOKEN` skips MR comments without failing report publishing;
+* API failures are logged clearly;
+* existing comments are updated in place when possible;
+* comments created by another token/user are not force-updated;
+* `latest/` links are not shown by default in MR comments;
+* the report link points to the immutable current `job_NNN/` snapshot.
+
+Preferred MR comment format:
+
+```markdown
+Allure: [report](REPORT_URL) · 42 passed · 2 skipped
+```
+
+For issue reports:
+
+```markdown
+Allure: [report](REPORT_URL) · **2 issues** · failed 1 · broken 1 · 44 total
+```
+
+Keep MR comments compact. Avoid headings, emoji, tables, and duplicate links.
+
+## Testing GitLab Component Changes
+
+When changing `templates/gitlab-allure-history.yml`, check:
+
+* component inputs still work;
+* default values are safe;
+* existing documented usage remains valid;
+* `allure-history-image-tag` is still handled correctly;
+* report publishing still works;
+* MR comments remain optional;
+* generated Pages layout remains compatible.
+
+Do not add new inputs casually.
+
+Each new input becomes part of the public component contract and must be documented and tested.
+
+Good component inputs affect actual behavior:
+
+* environment;
+* pages branch;
+* reports to keep;
+* Allure results directory;
+* MR comment enablement;
+* branch publishing rules.
+
+Avoid inputs for cosmetic details unless there is a strong reason.
+
+## Documentation Changes
+
+Update documentation when behavior changes.
+
+Usually affected files:
+
+```text
+README.md
+CHANGELOG.md
+CONTRIBUTING.md
+```
+
+README should stay user-facing:
+
+* what the project does;
+* why it exists;
+* how to use it;
+* required variables;
+* storage layout;
+* limitations.
+
+CONTRIBUTING should stay maintainer/contributor-facing:
+
+* how to test;
+* how to validate generated indexes;
+* how to reason about component changes;
+* release checklist;
+* project scope.
+
+## Changelog
+
+For user-visible changes, update `CHANGELOG.md`.
+
+Use the current unreleased section.
+
+Group changes under:
+
+```markdown
+### Added
+### Changed
+### Fixed
+### Breaking
+```
+
+Do not put new unreleased changes under an already released version.
+
+The project uses a year-based versioning scheme:
+
+```text
+YYYY.MINOR.PATCH
+```
+
+Component tags and runtime image tags are released together and should use the same version.
+
+## Pull Request Checklist
+
+Before opening or merging a pull request, check:
+
+```text
+[ ] Tests pass.
+[ ] Generated index behavior is covered when changed.
+[ ] latest/ behavior is covered when changed.
+[ ] pruning behavior is covered when changed.
+[ ] MR comment behavior is covered when changed.
+[ ] README is updated for user-facing changes.
+[ ] CHANGELOG is updated for release-visible changes.
+[ ] No unrelated refactoring is included.
+[ ] No generated report artifacts are committed accidentally.
+```
+
+## Release Checklist
+
+Before tagging a release:
+
+```text
+[ ] Merge request is reviewed and merged to master.
+[ ] Master pipeline is green.
+[ ] GitLab Pages root index opens.
+[ ] Environment index opens.
+[ ] Branch report index opens.
+[ ] latest/ opens and points to the newest job_NNN/ report.
+[ ] Old job_NNN/ report links still work.
+[ ] Issue result links still work if affected.
+[ ] MR comment behavior is checked if affected.
+[ ] README matches current behavior.
+[ ] CHANGELOG contains the release entry.
+[ ] Component version and runtime image tag match.
+[ ] Release tag is created.
+[ ] GitLab release notes are published.
+```
+
+## Design Principles
+
+Prefer:
+
+* static HTML;
+* simple CSS;
+* small vanilla JavaScript only when useful;
+* explicit GitLab CI behavior;
+* stable URLs;
+* predictable storage layout;
+* boring reliability.
+
+Avoid:
+
+* hidden magic;
+* large UI rewrites;
+* external frontend dependencies;
+* backend assumptions;
+* over-configurable cosmetic options;
+* features that turn the project into a report portal.
+
+The project should solve one problem well:
+
+```text
+Publish branch-based Allure report history to GitLab Pages with stable links and no extra infrastructure.
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,13 @@ Out of scope:
 
 This project should remain a static report publisher, not a mini ReportPortal.
 
+Operational constraints:
+
+* report history requires a writable Pages storage branch;
+* publishing is serialized with a `resource_group` and retries raced pushes up to three times;
+* different branch names can theoretically normalize to the same `CI_COMMIT_REF_SLUG`;
+* report retention defaults to 30 snapshots per environment and branch.
+
 ## Development Requirements
 
 * Python and `pip`;
@@ -66,13 +73,56 @@ pytest -m "demo"
 
 Demo tests may intentionally produce failed, broken, or skipped Allure states. They generate meaningful non-green example reports and are not a blocking gate.
 
+To test index generation directly:
+
+```bash
+python3 generate_index.py public
+```
+
+## How This Repository Uses Itself
+
+The project includes its own component from `.gitlab-ci.yml`. Tag pipelines build and use the matching release image. Non-tag pipelines include the component at the current commit SHA and use the latest published fallback image:
+
+```yaml
+include:
+  - component: $CI_SERVER_FQDN/$CI_PROJECT_PATH/gitlab-allure-history@$CI_COMMIT_TAG
+    inputs:
+      allure-history-image-tag: $CI_COMMIT_TAG
+      build-runtime-image: "true"
+    rules:
+      - if: $CI_COMMIT_TAG
+  - component: $CI_SERVER_FQDN/$CI_PROJECT_PATH/gitlab-allure-history@$CI_COMMIT_SHA
+    inputs:
+      allure-history-image-tag: "2026.2.8"
+    rules:
+      - if: $CI_COMMIT_TAG == null
+```
+
+After each release, update the fallback image tag in `.gitlab-ci.yml`.
+
 ## CI-only Validation
 
 These checks require GitLab CI context and variables; they are not normal local-only checks:
 
-* `ci_lint` validates GitLab CI and component configuration;
-* `consumer_contract:*` validates external consumer fixtures;
-* `pages_smoke` validates published GitLab Pages URLs.
+* `ci_lint` calls `validate_gitlab_ci.py` with the GitLab CI Lint API. It validates the current commit and checks that the component include expands to the expected `allure` job. It requires `ALLURE_HISTORY_TOKEN` with `api` scope.
+* `consumer_contract:*` executes each `tests/fixtures/consumer-*` configuration as a child pipeline against the component at the current commit SHA. Fixtures disable publishing and verify expanded inputs and upstream artifacts without modifying Pages content.
+* `pages_smoke` validates the published root, branch index, `latest/` alias, and immutable report URL.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `.gitlab-ci.yml` | Dogfooding, CI lint, consumer contracts, Pages smoke checks, and release jobs. |
+| `templates/gitlab-allure-history.yml` | Reusable GitLab CI component. |
+| `tests/fixtures/consumer-*` | External consumer configurations executed as child pipelines. |
+| `validate_gitlab_ci.py` | GitLab CI Lint API validation. |
+| `Dockerfile` | Runtime image with Python, Java, Git, and Allure CLI. |
+| `generate_index.py` | Static HTML index generator. |
+| `prune_reports.py` | Report snapshot retention. |
+| `smoke_public_pages.py` | Published Pages smoke checks. |
+| `pytest.ini` | Pytest markers and Allure configuration. |
+| `tests/` | Gate, component, and demo tests. |
+| `CHANGELOG.md` | Release history and policy. |
 
 ## Testing Generated Indexes
 
@@ -227,7 +277,8 @@ README should stay user-facing:
 * how to use it;
 * required variables;
 * storage layout;
-* limitations.
+* component inputs;
+* concise troubleshooting.
 
 CONTRIBUTING should stay maintainer/contributor-facing:
 
@@ -262,6 +313,13 @@ YYYY.MINOR.PATCH
 
 Component tags and runtime image tags are released together and should use the same version.
 
+## Release Workflow
+
+1. Merge the release changes to `master` with an updated changelog.
+2. Create a `YYYY.MINOR.PATCH` tag from the validated `master` commit.
+3. The tag pipeline includes the component at that tag, builds and pushes the matching runtime image through `build_python`, runs validation and publishing jobs, and creates the GitLab release through `create_release`.
+4. After the release succeeds, update the fallback runtime image tag in `.gitlab-ci.yml` for non-tag pipelines.
+
 ## Pull Request Checklist
 
 Before opening or merging a pull request, check:
@@ -278,7 +336,7 @@ Before opening or merging a pull request, check:
 
 ## Release Checklist
 
-Before tagging a release:
+Before tagging:
 
 - [ ] Merge request is reviewed and merged to master.
 - [ ] Master pipeline is green.
@@ -292,8 +350,14 @@ Before tagging a release:
 - [ ] README matches current behavior.
 - [ ] CHANGELOG contains the release entry.
 - [ ] Component version and runtime image tag match.
+
+After tagging:
+
 - [ ] Release tag is created.
+- [ ] Tag pipeline is green.
+- [ ] Matching runtime image is published.
 - [ ] GitLab release notes are published.
+- [ ] Non-tag fallback image in `.gitlab-ci.yml` is updated.
 
 ## Design Principles
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,15 @@ Out of scope:
 
 This project should remain a static report publisher, not a mini ReportPortal.
 
+## Development Requirements
+
+* Python and `pip`;
+* dependencies from `requirements.txt`;
+* GitLab CI/CD for full pipeline validation;
+* GitLab Pages and a writable Pages branch for publishing checks;
+* `GIT_PUSH_TOKEN` with `write_repository` permission for Pages publishing;
+* `ALLURE_HISTORY_TOKEN` with `api` scope for CI lint and MR comment checks.
+
 ## Development Setup
 
 Create a virtual environment:
@@ -43,25 +52,27 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-Run tests:
-
-```bash
-pytest
-```
-
-Run only non-demo tests:
+Run the blocking local gate:
 
 ```bash
 pytest -m "not demo"
 ```
 
-Run demo tests:
+Optionally run demo tests:
 
 ```bash
 pytest -m "demo"
 ```
 
-Demo tests may intentionally produce non-green Allure states. They exist to generate meaningful example reports.
+Demo tests may intentionally produce failed, broken, or skipped Allure states. They generate meaningful non-green example reports and are not a blocking gate.
+
+## CI-only Validation
+
+These checks require GitLab CI context and variables; they are not normal local-only checks:
+
+* `ci_lint` validates GitLab CI and component configuration;
+* `consumer_contract:*` validates external consumer fixtures;
+* `pages_smoke` validates published GitLab Pages URLs.
 
 ## Testing Generated Indexes
 
@@ -152,8 +163,9 @@ When changing MR comment logic, verify:
 * API failures are logged clearly;
 * existing comments are updated in place when possible;
 * comments created by another token/user are not force-updated;
-* `latest/` links are not shown by default in MR comments;
 * the report link points to the immutable current `job_NNN/` snapshot.
+
+MR comments must use the immutable current `job_NNN/` snapshot as evidence. The stable `latest/` alias belongs on index and navigation pages, not in MR comments.
 
 Preferred MR comment format:
 
@@ -254,38 +266,34 @@ Component tags and runtime image tags are released together and should use the s
 
 Before opening or merging a pull request, check:
 
-```text
-[ ] Tests pass.
-[ ] Generated index behavior is covered when changed.
-[ ] latest/ behavior is covered when changed.
-[ ] pruning behavior is covered when changed.
-[ ] MR comment behavior is covered when changed.
-[ ] README is updated for user-facing changes.
-[ ] CHANGELOG is updated for release-visible changes.
-[ ] No unrelated refactoring is included.
-[ ] No generated report artifacts are committed accidentally.
-```
+- [ ] Tests pass.
+- [ ] Generated index behavior is covered when changed.
+- [ ] `latest/` behavior is covered when changed.
+- [ ] Pruning behavior is covered when changed.
+- [ ] MR comment behavior is covered when changed.
+- [ ] README is updated for user-facing changes.
+- [ ] CHANGELOG is updated for release-visible changes.
+- [ ] No unrelated refactoring is included.
+- [ ] No generated report artifacts are committed accidentally.
 
 ## Release Checklist
 
 Before tagging a release:
 
-```text
-[ ] Merge request is reviewed and merged to master.
-[ ] Master pipeline is green.
-[ ] GitLab Pages root index opens.
-[ ] Environment index opens.
-[ ] Branch report index opens.
-[ ] latest/ opens and points to the newest job_NNN/ report.
-[ ] Old job_NNN/ report links still work.
-[ ] Issue result links still work if affected.
-[ ] MR comment behavior is checked if affected.
-[ ] README matches current behavior.
-[ ] CHANGELOG contains the release entry.
-[ ] Component version and runtime image tag match.
-[ ] Release tag is created.
-[ ] GitLab release notes are published.
-```
+- [ ] Merge request is reviewed and merged to master.
+- [ ] Master pipeline is green.
+- [ ] GitLab Pages root index opens.
+- [ ] Environment index opens.
+- [ ] Branch report index opens.
+- [ ] `latest/` opens and points to the newest `job_NNN/` report.
+- [ ] Old `job_NNN/` report links still work.
+- [ ] Issue result links still work if affected.
+- [ ] MR comment behavior is checked if affected.
+- [ ] README matches current behavior.
+- [ ] CHANGELOG contains the release entry.
+- [ ] Component version and runtime image tag match.
+- [ ] Release tag is created.
+- [ ] GitLab release notes are published.
 
 ## Design Principles
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![Latest Release](https://img.shields.io/gitlab/v/release/aleksandr-kotlyar/gitlab-allure-history?sort=semver)](https://gitlab.com/aleksandr-kotlyar/gitlab-allure-history/-/releases)
 
-Publish pytest Allure reports with preserved history to GitLab Pages, using only GitLab CI and static files. No report server, database, web framework, or external storage service is required.
+Publish Allure reports with preserved history to GitLab Pages using GitLab CI and static files. No report server, database, web framework, or external storage service is required.
 
-## Usage
+## Quick Start
 
-Include the component in your `.gitlab-ci.yml` and pin a release tag. The runtime image tag is resolved from the component version automatically:
+Include the component in `.gitlab-ci.yml` and pin a published release tag:
 
 ```yaml
 include:
@@ -31,56 +31,38 @@ test:
       - allure-results
 ```
 
-This is the only snippet you need to copy. The component creates an `allure` job that generates the HTML report, preserves history across runs, and publishes to GitLab Pages.
+The component adds an `allure` job that generates the HTML report, preserves history across runs, and publishes the result to GitLab Pages.
 
-**Prerequisites:**
-- A `gl-pages` storage branch (create once, see below)
-- A `GIT_PUSH_TOKEN` CI variable with `write_repository` permission
-- GitLab Pages enabled for the project
+## Prerequisites
 
----
+- GitLab Pages enabled for the project.
+- A `gl-pages` storage branch.
+- A `GIT_PUSH_TOKEN` CI variable with `write_repository` permission.
+- Test jobs that publish an `allure-results/` artifact.
 
-## Problem
+Create the storage branch once:
 
-Allure reports are easy to generate in CI, but they are usually temporary job artifacts. That makes it hard to see trends, compare recent runs, or share a stable report link with a team.
+```bash
+git checkout --orphan gl-pages
+git rm -rf .
+mkdir public
+touch public/.gitkeep
+git add public/.gitkeep
+git commit -m "Initialize report storage branch"
+git push origin gl-pages
+```
 
-GitLab Pages can host static reports, but a useful setup still needs to:
+Create a project, group, or personal access token with `write_repository` permission and store it as `GIT_PUSH_TOKEN`. Mark it protected only if reports are published exclusively from protected branches.
 
-- keep Allure `history` between pipeline runs;
-- avoid overwriting previous reports;
-- separate reports by branch;
-- make old reports easy to find;
-- stay simple enough to copy into another project.
-
-## Solution
-
-- pytest writes `allure-results`;
-- GitLab CI generates an Allure HTML report;
-- the previous branch `history` is copied into the next run;
-- each report is stored under a branch and job folder;
-- static indexes are generated for navigation;
-- the final `public/` folder is pushed to a dedicated `gl-pages` storage branch;
-- the report job publishes the same `public/` folder to GitLab Pages.
+Test jobs must save `allure-results/` with `artifacts.when: always`. They may also publish a `jobid` file containing the test job ID; otherwise, the report job uses its own `CI_JOB_ID` for the snapshot folder.
 
 ## How It Works
 
-```mermaid
-flowchart TD
-    A[pytest jobs] --> B[allure-results artifacts]
-    B --> C[allure job]
-    C --> D[Pull previous history from gl-pages]
-    D --> E[Generate new Allure report]
-    E --> F[Copy report to public branch/job folder]
-    F --> G[Update HTML indexes]
-    G --> H[Push public content to gl-pages]
-    H --> I[GitLab Pages]
-```
-
-Pipeline flow:
-
-1. `test` stage runs your tests and saves `allure-results/`.
-2. The `allure` job (from the component) downloads artifacts, restores previous branch history, generates the report, updates indexes, and pushes Pages content.
-3. The generated `public/` tree is saved to `gl-pages` for the next run and published as the GitLab Pages artifact.
+1. Test jobs publish `allure-results/`.
+2. The component restores the previous branch history from `gl-pages`.
+3. Allure generates a new immutable report snapshot.
+4. Static indexes and the stable `latest/` alias are updated.
+5. The `public/` tree is pushed to `gl-pages` and published by GitLab Pages.
 
 ## Report Storage Layout
 
@@ -99,82 +81,30 @@ public/
       job_NNN/
 ```
 
-- `public/{environment}/{branch-slug}/latest/` is a stable alias that
-  redirects to the newest report snapshot.
-- `public/{environment}/{branch-slug}/job_NNN/` is an immutable report
-  snapshot for a specific pipeline run.
-- `public/{environment}/{branch-slug}/history/` is copied into the next
-  run to preserve Allure trends.
-- `public/index.html` lists environment folders.
-- `public/{environment}/index.html` lists branch folders for that
-  environment.
-- `public/{environment}/{branch-slug}/index.html` lists reports for
-  that branch.
-
-The open demo pipeline uses `ENV` and `CI_COMMIT_REF_SLUG` for report
-folders, so the demo branch publishes to paths such as
-`public/dev/open-demo/`.
+- `latest/` redirects to the newest immutable `job_NNN/` snapshot.
+- `history/` is reused by the next run to preserve Allure trends.
+- Root, environment, and branch indexes provide navigation.
+- Branch folders use `CI_COMMIT_REF_SLUG` to keep paths URL-safe.
 
 ## Latest Report Links
 
-Each branch report folder gets a stable `latest/` alias.
+Use the stable latest-report URL:
 
-Use:
-
-`https://<pages-domain>/<project>/<environment>/<branch-slug>/latest/`
-
-when you need a stable link to the newest report. The `latest/`
-directory contains a lightweight HTML redirect to the most recent
-immutable `job_NNN/` snapshot.
-
-Use:
-
-`https://<pages-domain>/<project>/<environment>/<branch-slug>/job_NNN/`
-
-when you need an exact report snapshot for a specific pipeline run.
-
-- `latest/` is a static redirect, not a copy or symlink.
-- `job_NNN/` folders are immutable report snapshots.
-- `history/` is preserved for Allure trends and is not user-facing.
-
----
-
-## Detailed Setup
-
-### 1. Create the `gl-pages` Storage Branch
-
-```bash
-git checkout --orphan gl-pages
-git rm -rf .
-mkdir public
-touch public/.gitkeep
-git add public/.gitkeep
-git commit -m "Initialize report storage branch"
-git push origin gl-pages
+```text
+https://<pages-domain>/<project>/<environment>/<branch-slug>/latest/
 ```
 
-The `gl-pages` branch stores previous reports and Allure `history/` data.
+Use an immutable snapshot URL when linking to a specific pipeline result:
 
-### 2. Create a Push Token
+```text
+https://<pages-domain>/<project>/<environment>/<branch-slug>/job_NNN/
+```
 
-Create a project, group, or personal access token with `write_repository` permission and save it as a CI variable named `GIT_PUSH_TOKEN`.
+`latest/` is a static HTML redirect, not a report copy or symlink.
 
-Recommended settings:
-- Masked
-- Protected, if you publish only from protected branches
-- Unprotected, if you intentionally publish reports from feature branches
+## Version Pinning
 
-### 3. Add a Test Job
-
-Your test stage must:
-- Run `pytest --alluredir=allure-results`.
-- Save `allure-results/` as a CI artifact (use `when: always` so artifacts are saved even on failure).
-
-A test job may also upload a `jobid` file containing the test job ID. When absent, the report job uses its own `CI_JOB_ID` for the `job_NNN` snapshot folder.
-
-### 4. Include the Component
-
-Pin a release tag. The runtime image tag resolves from the component version automatically:
+Component and runtime image tags are released as a matched pair. A tagged component reference resolves the matching runtime image tag automatically:
 
 ```yaml
 include:
@@ -183,7 +113,7 @@ include:
       environment: dev
 ```
 
-Set `allure-history-image-tag` explicitly when using a SHA or branch reference, or to override the image tag:
+Use a published release tag for normal use. When using a full commit SHA or branch reference, set the runtime image tag explicitly:
 
 ```yaml
 include:
@@ -192,46 +122,7 @@ include:
       allure-history-image-tag: "2026.2.9"
 ```
 
-The component adds an `allure` job that handles report generation, indexing, and publishing.
-
----
-
-## Versioning And Release Policy
-
-Component version and runtime image tag are released together as a matched pair. When you pin a component release tag (e.g. `@2026.2.9`), the runtime image tag resolves automatically from the component version.
-
-```
-Component:  gitlab-allure-history@2026.2.9
-Image tag:  allure-history-image-tag: 2026.2.9 (auto-resolved)
-```
-
-**Pin the component to a release tag.** The image tag follows automatically.
-
-The version scheme is `YYYY.MINOR.PATCH` (year-based versioning scheme). The full release history is in [CHANGELOG.md](CHANGELOG.md).
-
-### Why Pin?
-
-Never use moving references (branches, `~latest`) for production pipelines. A moving reference can change CI behavior without a merge request in the consuming project, creating silent failures or unexpected behavior.
-
-Prefer a release tag for normal use. Use a full commit SHA when you need maximum immutability (the component resolves `@<sha>` to that commit and the tag pipeline is not required).
-
-### Matching Versions
-
-When you include:
-
-```yaml
-  - component: .../gitlab-allure-history@2026.2.9
-```
-
-use:
-
-```yaml
-    allure-history-image-tag: 2026.2.9
-```
-
-The default runtime image is `registry.gitlab.com/aleksandr-kotlyar/gitlab-allure-history:<tag>`. If you use a project-owned image repository, publish images with the same tags as the component versions, and ensure the image contains `generate_index.py`, `prune_reports.py`, `git`, `python3`, and the `allure` commandline.
-
----
+The version scheme is `YYYY.MINOR.PATCH`. See [CHANGELOG.md](CHANGELOG.md) for release history.
 
 ## Component Inputs
 
@@ -239,136 +130,62 @@ The default runtime image is `registry.gitlab.com/aleksandr-kotlyar/gitlab-allur
 |-------|---------|-------------|
 | `environment` | `dev` | Report environment folder under `public/`. |
 | `allure-history-image` | `registry.gitlab.com/...` | Runtime image repository. |
-| `allure-history-image-tag` | `$[[ component.version ]]` | Runtime image tag. Auto-resolved when using a tagged component reference. |
-| `allure-history-tools-dir` | `/opt/gitlab-allure-history` | Directory with `generate_index.py` and `prune_reports.py`. |
+| `allure-history-image-tag` | `$[[ component.version ]]` | Runtime image tag. Set explicitly for SHA or branch component references. |
+| `allure-history-tools-dir` | `/opt/gitlab-allure-history` | **Advanced custom image override.** Directory containing `generate_index.py` and `prune_reports.py`. |
 | `pages-branch` | `gl-pages` | Branch that stores Pages content and Allure history. |
-| `reports-to-keep` | `30` | Number of report snapshots kept per environment and branch. |
-| `build-runtime-image` | `false` | Build and push the runtime image in tag pipelines (for this repo's release pipeline). |
-| `comment-mr` | `false` | Post or update a merge request comment with the latest report URL. |
+| `reports-to-keep` | `30` | Report snapshots retained per environment and branch. |
+| `build-runtime-image` | `false` | **Maintainer/release input.** Build and push this project's runtime image in tag pipelines. |
+| `comment-mr` | `false` | Post or update a merge request comment with the current immutable report URL. |
 
 ### Optional CI Variables
 
-- `ALLURE_HISTORY_INDEX_DESKTOP_BATCH_SIZE`: index rows before `Show more...` on desktop. Default `25`. Set to `0` for no limit.
-- `ALLURE_HISTORY_INDEX_MOBILE_BATCH_SIZE`: index rows before `Show more...` on mobile. Default `12`. Set to `0` for no limit.
-- `ALLURE_HISTORY_TOKEN`: token with `api` scope for MR comments. Falls back to `CI_JOB_TOKEN`.
+- `ALLURE_HISTORY_INDEX_DESKTOP_BATCH_SIZE`: rows shown before `Show more...` on desktop. Default `25`; set to `0` for no limit.
+- `ALLURE_HISTORY_INDEX_MOBILE_BATCH_SIZE`: rows shown before `Show more...` on mobile. Default `12`; set to `0` for no limit.
+- `ALLURE_HISTORY_TOKEN`: token with `api` scope for merge request comments. Without it, comments are skipped.
 
-### Provided by GitLab CI
+### GitLab CI Values Used
 
-- `ENV`: report environment folder (defaults to `dev`).
+- `ENV`: report environment folder, populated from the `environment` input.
 - `CI_COMMIT_REF_SLUG`: branch report folder.
-- `CI_JOB_ID`: report snapshot folder (when no `jobid` artifact is provided).
-- `CI_PAGES_URL`: Allure executor metadata.
-- `CI_PIPELINE_URL`: Allure report link.
+- `CI_JOB_ID`: fallback report snapshot ID when no `jobid` artifact exists.
+- `CI_PAGES_URL`: report URL metadata.
+- `CI_PIPELINE_URL`: pipeline URL metadata.
 
-The runner needs network access to pull the CI image, clone and push the `gl-pages` branch, and upload the `public/` artifact.
+The runner needs network access to pull the runtime image, clone and push the Pages branch, and upload the `public/` artifact.
 
----
+## Demo
 
-## How This Repository Uses Itself
-
-This project dogfoods its own component. Tag pipelines use `@$CI_COMMIT_TAG` with the matching image tag. Non-tag pipelines use `@$CI_COMMIT_SHA` with a pinned fallback image tag:
-
-```yaml
-include:
-  - component: $CI_SERVER_FQDN/$CI_PROJECT_PATH/gitlab-allure-history@$CI_COMMIT_TAG
-    inputs:
-      allure-history-image-tag: $CI_COMMIT_TAG
-      build-runtime-image: "true"
-    rules:
-      - if: $CI_COMMIT_TAG
-  - component: $CI_SERVER_FQDN/$CI_PROJECT_PATH/gitlab-allure-history@$CI_COMMIT_SHA
-    inputs:
-      allure-history-image-tag: "2026.2.9"
-    rules:
-      - if: $CI_COMMIT_TAG == null
-```
-
-The `build_python` job builds and pushes `$CI_REGISTRY_IMAGE:$CI_COMMIT_TAG` during tag pipelines, so the component version and the runtime image tag are always the same release value.
-
-The repository pipeline reuses the masked `ALLURE_HISTORY_TOKEN` with `api`
-scope. The `ci_lint` job uses it to statically validate the current commit
-through the GitLab CI Lint API and verify that the component include expands
-to the `allure` job.
-
----
-
-## Local Run
-
-```bash
-python3 -m venv .venv
-./.venv/bin/pip install -r requirements.txt
-
-./.venv/bin/pytest -m "not demo"   # blocking gate tests
-./.venv/bin/pytest -m "demo"       # non-blocking demo tests
-python3 generate_index.py public   # test index generation
-```
-
-The demo suite intentionally contains failed, broken, skipped, and passed examples. It is useful for demonstrating Allure output but is not a blocking quality gate.
-
----
-
-## Key Files
-
-| File | Purpose |
-|------|---------|
-| `.gitlab-ci.yml` | Dogfooding pipeline |
-| `templates/gitlab-allure-history.yml` | Reusable CI component |
-| `tests/fixtures/consumer-*` | External consumer contracts executed as child pipelines |
-| `Dockerfile` | Runtime image with Python, Java, Git, Allure CLI |
-| `generate_index.py` | Static HTML index generator |
-| `prune_reports.py` | Removes old report snapshots |
-| `pytest.ini` | Pytest markers and Allure config |
-| `conftest.py` | Pytest fixtures |
-| `tests/` | Gate and demo tests |
-| `CHANGELOG.md` | Release history and policy |
-
-The `consumer_contract:*` CI jobs execute every consumer fixture as a child
-pipeline against the component at the current commit SHA. Fixtures disable the
-publishing job and verify the expanded inputs and upstream artifacts without
-changing Pages content.
-
-## Demo Links
-
-- GitLab mirror: [gitlab.com/aleksandr-kotlyar/gitlab-allure-history](https://gitlab.com/aleksandr-kotlyar/gitlab-allure-history)
-- Pages report: [aleksandr-kotlyar.gitlab.io/gitlab-allure-history](https://aleksandr-kotlyar.gitlab.io/gitlab-allure-history/)
-
-## Limitations And Trade-Offs
-
-- Report history depends on a writable `gl-pages` storage branch.
-- The CI serializes the Pages publishing job with `resource_group` and retries a raced `gl-pages` push up to three times; sustained conflicts still fail the job.
-- `CI_COMMIT_REF_SLUG` keeps report paths URL-safe, but different branch names can theoretically normalize to the same slug.
-- The CI keeps the latest 30 report snapshots per branch by default.
-- This project is a GitLab CI/CD component, not a report portal or framework.
+- GitLab project: [gitlab.com/aleksandr-kotlyar/gitlab-allure-history](https://gitlab.com/aleksandr-kotlyar/gitlab-allure-history)
+- Published reports: [aleksandr-kotlyar.gitlab.io/gitlab-allure-history](https://aleksandr-kotlyar.gitlab.io/gitlab-allure-history/)
 
 ## Troubleshooting
 
 ### `gl-pages` Branch Not Found
 
-Create the `gl-pages` branch before running the report job.
+Create the storage branch before running the report job.
 
 ### Report Job Cannot Push
 
-Check that `GIT_PUSH_TOKEN` exists, is available to the branch running the pipeline, and has `write_repository` permission. If the variable is protected, pipelines on unprotected branches cannot use it.
+Check that `GIT_PUSH_TOKEN` is available to the pipeline and has `write_repository` permission. Protected variables are unavailable on unprotected branches.
 
 ### No Previous History
 
-The first run for a branch has no previous Allure history. The report still publishes, and the next run reuses the generated `history/` folder.
+The first run for a branch has no previous history. The report still publishes, and later runs reuse the generated `history/` folder.
 
-### Pages Index Shows A Slug Instead Of The Original Branch Name
+### Branch Name Appears As A Slug
 
-This is expected. The template stores reports by `CI_COMMIT_REF_SLUG` to keep static paths URL-safe.
-
-### Demo Tests Fail
-
-This is expected. `test_demo` is marked `allow_failure: true` in GitLab CI and exists to show how failed and broken tests appear in Allure.
+This is expected. Report paths use `CI_COMMIT_REF_SLUG`.
 
 ## Roadmap
 
-- tune how many report snapshots are kept per branch;
-- ~~add links from merge requests to the latest report;~~ (implemented via `comment-mr` input)
-- publish only from selected branches;
-- add screenshots or videos as Allure attachments;
-- replace the example CI image with a project-owned image.
+- Add an `allure-results-dir` input.
+- Add a `publish-branch-regex` input.
+- Document compatibility with non-pytest Allure producers.
+- Investigate Allure Report 3 compatibility.
+
+## Contributing
+
+Development setup, repository CI details, testing, scope, and release procedures are documented in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 

--- a/tests/test_gitlab_template.py
+++ b/tests/test_gitlab_template.py
@@ -101,7 +101,7 @@ def test_project_pipeline_dogfoods_reusable_template():
 
 def test_project_pipeline_validates_expanded_component_with_ci_lint_api():
     pipeline = Path(".gitlab-ci.yml").read_text(encoding="utf-8")
-    readme = Path("README.md").read_text(encoding="utf-8")
+    contributing = Path("CONTRIBUTING.md").read_text(encoding="utf-8")
 
     assert "ci_lint:\n  stage: test\n" in pipeline
     assert '    - test -n "${ALLURE_HISTORY_TOKEN:-}"' in pipeline
@@ -110,7 +110,8 @@ def test_project_pipeline_validates_expanded_component_with_ci_lint_api():
     assert '        --project-id "$CI_PROJECT_ID"' in pipeline
     assert '        --ref "$CI_COMMIT_SHA"' in pipeline
     assert '        --private-token "$ALLURE_HISTORY_TOKEN"' in pipeline
-    assert "reuses the masked `ALLURE_HISTORY_TOKEN` with `api`" in readme
+    assert "`ci_lint` calls `validate_gitlab_ci.py` with the GitLab CI Lint API" in contributing
+    assert "requires `ALLURE_HISTORY_TOKEN` with `api` scope" in contributing
 
 
 def test_project_pipeline_smokes_published_pages_after_allure():
@@ -320,5 +321,5 @@ def test_readme_external_include_uses_pinned_component_version():
         "gitlab-allure-history@2026.2.9"
         in readme
     )
-    assert "allure-history-image-tag: 2026.2.9" in readme
-    assert "Never use moving references (branches, `~latest`)" in readme
+    assert 'allure-history-image-tag: "2026.2.9"' in readme
+    assert "pin a published release tag" in readme


### PR DESCRIPTION
- keep README focused on external users
- move development, CI, testing, scope, and release guidance to CONTRIBUTING.md
- mark advanced and maintainer-only component inputs