### PR TITLE
Publish GitLab Pages from the component pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -117,7 +117,7 @@ consumer_contract:custom-pages-branch:
       - local: tests/fixtures/consumer-custom-pages-branch/.gitlab-ci.yml
     strategy: mirror
 
-allure:
+publish-allure-history:
   rules:
     - if: $CI_PIPELINE_SOURCE == "web"
       when: never
@@ -133,7 +133,7 @@ pages_smoke:
   needs:
     - job: test_gate
       artifacts: true
-    - job: allure
+    - job: publish-allure-history
       artifacts: false
   rules:
     - if: $CI_PIPELINE_SOURCE == "web"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,7 @@ After each release, update the fallback image tag in `.gitlab-ci.yml`.
 
 These checks require GitLab CI context and variables; they are not normal local-only checks:
 
-* `ci_lint` calls `validate_gitlab_ci.py` with the GitLab CI Lint API. It validates the current commit and checks that the component include expands to the expected `allure` job. It requires `ALLURE_HISTORY_TOKEN` with `api` scope.
+* `ci_lint` calls `validate_gitlab_ci.py` with the GitLab CI Lint API. It validates the current commit and checks that the component include expands to the expected `publish-allure-history` job. It requires `ALLURE_HISTORY_TOKEN` with `api` scope.
 * `consumer_contract:*` executes each `tests/fixtures/consumer-*` configuration as a child pipeline against the component at the current commit SHA. Fixtures disable publishing and verify expanded inputs and upstream artifacts without modifying Pages content.
 * `pages_smoke` validates the published root, branch index, `latest/` alias, and immutable report URL.
 

--- a/README.md
+++ b/README.md
@@ -45,25 +45,12 @@ The component adds an `allure` job that generates the HTML report, preserves his
 ## Prerequisites
 
 - GitLab Pages enabled for the project.
-- A `gl-pages` persistent storage branch that exists before the first component run.
 - A `GIT_PUSH_TOKEN` CI variable with `write_repository` permission.
 - Test jobs that publish an `allure-results/` artifact.
 
-Create the storage branch once before the first run:
+The component creates the `gl-pages` persistent storage branch automatically on the first run if it does not exist. The branch stores generated `public/` content and history; it is not a deployment pipeline branch and does not need its own `.gitlab-ci.yml`.
 
-```bash
-git checkout --orphan gl-pages
-git rm -rf .
-mkdir public
-touch public/.gitkeep
-git add public/.gitkeep
-git commit -m "Initialize report storage branch"
-git push origin gl-pages
-```
-
-`gl-pages` stores generated `public/` content and history; it is not a deployment pipeline branch and does not need its own `.gitlab-ci.yml`.
-
-Create a project, group, or personal access token with `write_repository` permission and store it as `GIT_PUSH_TOKEN`. The token must be allowed to push to `gl-pages`, including when branch protection is enabled. Mark it protected only if reports are published exclusively from protected branches.
+Create a project, group, or personal access token with `write_repository` permission and store it as `GIT_PUSH_TOKEN`. The token must be allowed to create and push to `gl-pages`, including when branch protection is enabled. Mark it protected only if reports are published exclusively from protected branches.
 
 Test jobs must save `allure-results/` with `artifacts.when: always`. They may also publish a `jobid` file containing the test job ID; otherwise, the report job uses its own `CI_JOB_ID` for the snapshot folder.
 
@@ -186,9 +173,9 @@ The runner needs network access to pull the runtime image, clone and push the Pa
 
 ## Troubleshooting
 
-### `gl-pages` Branch Not Found
+### Storage Branch Cannot Be Created
 
-Create the storage branch before running the report job.
+Check that `GIT_PUSH_TOKEN` is allowed to create and push the configured storage branch. If branch protection requires pre-creation by a maintainer, create the branch once and rerun the pipeline.
 
 ### Report Job Cannot Push
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ test:
       - allure-results
 ```
 
-The component adds an `allure` job that generates the HTML report, preserves history across runs, pushes the generated content to the storage branch, and publishes GitLab Pages from the main/component pipeline.
+The component adds a `publish-allure-history` job that generates the HTML report, preserves history across runs, pushes the generated content to the storage branch, and publishes GitLab Pages from the main/component pipeline.
 
 > [!WARNING]
 > This component publishes the project's GitLab Pages site from `public/`. If the project already uses GitLab Pages for another site, use a dedicated project for Allure history or avoid conflicting Pages deployments.
@@ -75,7 +75,7 @@ Test jobs must save `allure-results/` with `artifacts.when: always`. They may al
 3. Allure generates a new immutable report snapshot.
 4. Static indexes and the stable `latest/` alias are updated.
 5. The `public/` tree is committed to `gl-pages` with CI skipped for persistent storage.
-6. The same `public/` tree is uploaded by the `allure` job and published by GitLab Pages from the main/component pipeline.
+6. The same `public/` tree is uploaded by the `publish-allure-history` job and published by GitLab Pages from the main/component pipeline.
 
 ## Report Storage Layout
 

--- a/README.md
+++ b/README.md
@@ -37,16 +37,19 @@ test:
       - allure-results
 ```
 
-The component adds an `allure` job that generates the HTML report, preserves history across runs, and publishes the result to GitLab Pages.
+The component adds an `allure` job that generates the HTML report, preserves history across runs, pushes the generated content to the storage branch, and publishes GitLab Pages from the main/component pipeline.
+
+> [!WARNING]
+> This component publishes the project's GitLab Pages site from `public/`. If the project already uses GitLab Pages for another site, use a dedicated project for Allure history or avoid conflicting Pages deployments.
 
 ## Prerequisites
 
 - GitLab Pages enabled for the project.
-- A `gl-pages` storage branch.
+- A `gl-pages` persistent storage branch that exists before the first component run.
 - A `GIT_PUSH_TOKEN` CI variable with `write_repository` permission.
 - Test jobs that publish an `allure-results/` artifact.
 
-Create the storage branch once:
+Create the storage branch once before the first run:
 
 ```bash
 git checkout --orphan gl-pages
@@ -58,7 +61,9 @@ git commit -m "Initialize report storage branch"
 git push origin gl-pages
 ```
 
-Create a project, group, or personal access token with `write_repository` permission and store it as `GIT_PUSH_TOKEN`. Mark it protected only if reports are published exclusively from protected branches.
+`gl-pages` stores generated `public/` content and history; it is not a deployment pipeline branch and does not need its own `.gitlab-ci.yml`.
+
+Create a project, group, or personal access token with `write_repository` permission and store it as `GIT_PUSH_TOKEN`. The token must be allowed to push to `gl-pages`, including when branch protection is enabled. Mark it protected only if reports are published exclusively from protected branches.
 
 Test jobs must save `allure-results/` with `artifacts.when: always`. They may also publish a `jobid` file containing the test job ID; otherwise, the report job uses its own `CI_JOB_ID` for the snapshot folder.
 
@@ -82,11 +87,12 @@ Test jobs must save `allure-results/` with `artifacts.when: always`. They may al
 2. The component restores the previous branch history from `gl-pages`.
 3. Allure generates a new immutable report snapshot.
 4. Static indexes and the stable `latest/` alias are updated.
-5. The `public/` tree is pushed to `gl-pages` and published by GitLab Pages.
+5. The `public/` tree is committed to `gl-pages` with CI skipped for persistent storage.
+6. The same `public/` tree is uploaded by the `allure` job and published by GitLab Pages from the main/component pipeline.
 
 ## Report Storage Layout
 
-Reports are persisted in the `gl-pages` branch:
+Reports are persisted in the `gl-pages` storage branch. The branch contains generated content, not a separate Pages deployment pipeline:
 
 ```text
 public/
@@ -152,7 +158,7 @@ The version scheme is `YYYY.MINOR.PATCH`. See [CHANGELOG.md](CHANGELOG.md) for r
 | `allure-history-image` | `registry.gitlab.com/...` | Runtime image repository. |
 | `allure-history-image-tag` | `$[[ component.version ]]` | Runtime image tag. Set explicitly for SHA or branch component references. |
 | `allure-history-tools-dir` | `/opt/gitlab-allure-history` | **Advanced custom image override.** Directory containing `generate_index.py` and `prune_reports.py`. |
-| `pages-branch` | `gl-pages` | Branch that stores Pages content and Allure history. |
+| `pages-branch` | `gl-pages` | Persistent storage branch for generated Pages content and Allure history. |
 | `reports-to-keep` | `30` | Report snapshots retained per environment and branch. |
 | `build-runtime-image` | `false` | **Maintainer/release input.** Build and push this project's runtime image in tag pipelines. |
 | `comment-mr` | `false` | Post or update a merge request comment with the current immutable report URL. |
@@ -186,7 +192,7 @@ Create the storage branch before running the report job.
 
 ### Report Job Cannot Push
 
-Check that `GIT_PUSH_TOKEN` is available to the pipeline and has `write_repository` permission. Protected variables are unavailable on unprotected branches.
+Check that `GIT_PUSH_TOKEN` is available to the pipeline, has `write_repository` permission, and is allowed to push to `gl-pages`. Protected variables are unavailable on unprotected branches.
 
 ### No Previous History
 

--- a/templates/gitlab-allure-history.yml
+++ b/templates/gitlab-allure-history.yml
@@ -70,7 +70,7 @@ build_python:
     - docker build -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
     - docker push "$CI_REGISTRY_IMAGE:$IMAGE_TAG"
 
-allure:
+publish-allure-history:
   image: $ALLURE_HISTORY_IMAGE
   stage: report
   resource_group: pages-publish

--- a/templates/gitlab-allure-history.yml
+++ b/templates/gitlab-allure-history.yml
@@ -248,12 +248,14 @@ allure:
       git -C pages-worktree config user.email "${GITLAB_USER_EMAIL:-gitlab-ci@example.invalid}"
       git -C pages-worktree remote set-url origin "https://oauth2:${GIT_PUSH_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git"
 
+      rm -f pages-worktree/.gitlab-ci.yml
       git -C pages-worktree add public
+      git -C pages-worktree rm -f --ignore-unmatch .gitlab-ci.yml
 
       if git -C pages-worktree diff --cached --quiet; then
         echo "No Pages changes to publish."
       else
-        git -C pages-worktree commit -m "Publish Allure report for pipeline ${CI_PIPELINE_ID}"
+        git -C pages-worktree commit -m "Publish Allure report for pipeline ${CI_PIPELINE_ID} [skip ci]"
 
         PAGES_PUSH_ATTEMPT=1
         PAGES_PUSH_MAX_ATTEMPTS=3
@@ -261,7 +263,7 @@ allure:
         while [ "$PAGES_PUSH_ATTEMPT" -le "$PAGES_PUSH_MAX_ATTEMPTS" ]; do
           git -C pages-worktree pull --rebase origin "$PAGES_BRANCH"
 
-          if git -C pages-worktree push origin "HEAD:$PAGES_BRANCH"; then
+          if git -C pages-worktree push -o ci.skip origin "HEAD:$PAGES_BRANCH"; then
             break
           fi
 

--- a/templates/gitlab-allure-history.yml
+++ b/templates/gitlab-allure-history.yml
@@ -117,8 +117,18 @@ allure:
       fi
 
     - |
-      if ! git clone --single-branch --branch "$PAGES_BRANCH" "$CI_REPOSITORY_URL" pages-worktree; then
-        echo "Failed to clone '${PAGES_BRANCH}' from this project. Create the '${PAGES_BRANCH}' branch before publishing reports."
+      PAGES_BRANCH_STATUS=0
+      git ls-remote --exit-code --heads "$CI_REPOSITORY_URL" "refs/heads/$PAGES_BRANCH" >/dev/null 2>&1 || PAGES_BRANCH_STATUS=$?
+
+      if [ "$PAGES_BRANCH_STATUS" -eq 0 ]; then
+        git clone --single-branch --branch "$PAGES_BRANCH" "$CI_REPOSITORY_URL" pages-worktree
+      elif [ "$PAGES_BRANCH_STATUS" -eq 2 ]; then
+        echo "Storage branch '${PAGES_BRANCH}' does not exist; creating it."
+        git init pages-worktree
+        git -C pages-worktree remote add origin "$CI_REPOSITORY_URL"
+        git -C pages-worktree checkout --orphan "$PAGES_BRANCH"
+      else
+        echo "Failed to check storage branch '${PAGES_BRANCH}'. Verify repository access and CI network settings."
         exit 1
       fi
 
@@ -261,7 +271,15 @@ allure:
         PAGES_PUSH_MAX_ATTEMPTS=3
 
         while [ "$PAGES_PUSH_ATTEMPT" -le "$PAGES_PUSH_MAX_ATTEMPTS" ]; do
-          git -C pages-worktree pull --rebase origin "$PAGES_BRANCH"
+          REMOTE_BRANCH_STATUS=0
+          git -C pages-worktree ls-remote --exit-code --heads origin "refs/heads/$PAGES_BRANCH" >/dev/null 2>&1 || REMOTE_BRANCH_STATUS=$?
+
+          if [ "$REMOTE_BRANCH_STATUS" -eq 0 ]; then
+            git -C pages-worktree pull --rebase origin "$PAGES_BRANCH"
+          elif [ "$REMOTE_BRANCH_STATUS" -ne 2 ]; then
+            echo "Failed to check remote storage branch '${PAGES_BRANCH}'."
+            exit 1
+          fi
 
           if git -C pages-worktree push -o ci.skip origin "HEAD:$PAGES_BRANCH"; then
             break

--- a/tests/fixtures/consumer-custom-env/.gitlab-ci.yml
+++ b/tests/fixtures/consumer-custom-env/.gitlab-ci.yml
@@ -21,7 +21,7 @@ consumer_contract:
   tags:
     - macos-local
 
-allure:
+publish-allure-history:
   rules:
     - when: never
 

--- a/tests/fixtures/consumer-custom-pages-branch/.gitlab-ci.yml
+++ b/tests/fixtures/consumer-custom-pages-branch/.gitlab-ci.yml
@@ -21,7 +21,7 @@ consumer_contract:
   tags:
     - macos-local
 
-allure:
+publish-allure-history:
   rules:
     - when: never
 

--- a/tests/fixtures/consumer-minimal/.gitlab-ci.yml
+++ b/tests/fixtures/consumer-minimal/.gitlab-ci.yml
@@ -20,7 +20,7 @@ consumer_contract:
   tags:
     - macos-local
 
-allure:
+publish-allure-history:
   rules:
     - when: never
 

--- a/tests/fixtures/consumer-without-jobid/.gitlab-ci.yml
+++ b/tests/fixtures/consumer-without-jobid/.gitlab-ci.yml
@@ -18,7 +18,7 @@ consumer_contract:
   tags:
     - macos-local
 
-allure:
+publish-allure-history:
   rules:
     - when: never
 

--- a/tests/test_consumer_contracts.py
+++ b/tests/test_consumer_contracts.py
@@ -53,7 +53,7 @@ def test_consumer_fixture_uses_external_component_contract(name):
     assert "consumer_contract:" in content
     assert "allure-results" in content
     assert "verify_consumer_contract:" in content
-    assert "allure:\n  rules:\n    - when: never" in content
+    assert "publish-allure-history:\n  rules:\n    - when: never" in content
     assert content.count("  tags:\n    - macos-local") == 2
 
 

--- a/tests/test_gitlab_template.py
+++ b/tests/test_gitlab_template.py
@@ -160,6 +160,22 @@ def test_template_defines_component_inputs():
     assert "---\n\nvariables:" in template
 
 
+def test_allure_job_publishes_public_as_gitlab_pages_artifact():
+    template = Path("templates/gitlab-allure-history.yml").read_text(encoding="utf-8")
+    allure_job = template.split("\nallure:\n", 1)[1]
+
+    assert "\n  pages: true\n" in allure_job
+    assert (
+        "  artifacts:\n"
+        "    when: always\n"
+        "    expire_in: 1 week\n"
+        "    paths:\n"
+        "      - public\n"
+    ) in allure_job
+    assert "\npublish-allure-history:" not in template
+    assert "\n  tags:" not in template
+
+
 def run_pages_publish_script(tmp_path, monkeypatch, successful_push):
     template = Path("templates/gitlab-allure-history.yml").read_text(encoding="utf-8")
     script = extract_script_block(
@@ -173,6 +189,7 @@ def run_pages_publish_script(tmp_path, monkeypatch, successful_push):
         textwrap.dedent(
             """\
             #!/bin/sh
+            printf '%s\n' "$*" >> "$GIT_COMMANDS"
             command="$3"
 
             case "$command" in
@@ -200,11 +217,17 @@ def run_pages_publish_script(tmp_path, monkeypatch, successful_push):
     pages_public = tmp_path / "pages-worktree" / "public"
     pages_public.mkdir(parents=True)
     (pages_public / "index.html").write_text("report", encoding="utf-8")
+    (tmp_path / "pages-worktree" / ".gitlab-ci.yml").write_text(
+        "pages:\n  script: echo legacy\n",
+        encoding="utf-8",
+    )
     calls_file = tmp_path / "git-calls"
+    commands_file = tmp_path / "git-commands"
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("PATH", f"{bin_dir}:{Path('/usr/bin')}:{Path('/bin')}")
     monkeypatch.setenv("GIT_CALLS", str(calls_file))
+    monkeypatch.setenv("GIT_COMMANDS", str(commands_file))
     monkeypatch.setenv("SUCCESSFUL_PUSH", str(successful_push))
     monkeypatch.setenv("GIT_PUSH_TOKEN", "secret")
     monkeypatch.setenv("CI_SERVER_HOST", "gitlab.example")
@@ -212,15 +235,21 @@ def run_pages_publish_script(tmp_path, monkeypatch, successful_push):
     monkeypatch.setenv("CI_PIPELINE_ID", "123")
     monkeypatch.setenv("PAGES_BRANCH", "gl-pages")
 
-    return subprocess.run(
+    result = subprocess.run(
         ["sh", "-eu", "-c", script],
         text=True,
         capture_output=True,
-    ), calls_file
+    )
+
+    return result, calls_file, commands_file
 
 
 def test_pages_push_retries_after_racing_updates(tmp_path, monkeypatch):
-    result, calls_file = run_pages_publish_script(tmp_path, monkeypatch, successful_push=3)
+    result, calls_file, commands_file = run_pages_publish_script(
+        tmp_path,
+        monkeypatch,
+        successful_push=3,
+    )
 
     assert result.returncode == 0
     assert calls_file.read_text(encoding="utf-8").splitlines() == [
@@ -234,10 +263,27 @@ def test_pages_push_retries_after_racing_updates(tmp_path, monkeypatch):
     assert "Pages push attempt 1/3 failed" in result.stdout
     assert "Pages push attempt 2/3 failed" in result.stdout
     assert (tmp_path / "public" / "index.html").read_text(encoding="utf-8") == "report"
+    assert not (tmp_path / "pages-worktree" / ".gitlab-ci.yml").exists()
+
+    commands = commands_file.read_text(encoding="utf-8").splitlines()
+    assert any(
+        command.endswith(
+            "commit -m Publish Allure report for pipeline 123 [skip ci]"
+        )
+        for command in commands
+    )
+    assert sum(
+        command.endswith("push -o ci.skip origin HEAD:gl-pages")
+        for command in commands
+    ) == 3
 
 
 def test_pages_push_fails_after_three_attempts(tmp_path, monkeypatch):
-    result, calls_file = run_pages_publish_script(tmp_path, monkeypatch, successful_push=0)
+    result, calls_file, _ = run_pages_publish_script(
+        tmp_path,
+        monkeypatch,
+        successful_push=0,
+    )
 
     assert result.returncode == 1
     assert calls_file.read_text(encoding="utf-8").splitlines().count("push") == 3

--- a/tests/test_gitlab_template.py
+++ b/tests/test_gitlab_template.py
@@ -176,7 +176,94 @@ def test_allure_job_publishes_public_as_gitlab_pages_artifact():
     assert "\n  tags:" not in template
 
 
-def run_pages_publish_script(tmp_path, monkeypatch, successful_push):
+def run_storage_checkout_script(tmp_path, monkeypatch, branch_status):
+    template = Path("templates/gitlab-allure-history.yml").read_text(encoding="utf-8")
+    script = extract_script_block(
+        template,
+        "      PAGES_BRANCH_STATUS=0",
+    )
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_git = bin_dir / "git"
+    fake_git.write_text(
+        textwrap.dedent(
+            """\
+            #!/bin/sh
+            printf '%s\n' "$*" >> "$GIT_COMMANDS"
+
+            if [ "$1" = "ls-remote" ]; then
+              exit "$BRANCH_STATUS"
+            fi
+
+            if [ "$1" = "init" ]; then
+              mkdir -p "$2"
+            fi
+            """
+        ),
+        encoding="utf-8",
+    )
+    fake_git.chmod(0o755)
+    commands_file = tmp_path / "git-commands"
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("PATH", f"{bin_dir}:{Path('/usr/bin')}:{Path('/bin')}")
+    monkeypatch.setenv("GIT_COMMANDS", str(commands_file))
+    monkeypatch.setenv("BRANCH_STATUS", str(branch_status))
+    monkeypatch.setenv("CI_REPOSITORY_URL", "https://gitlab.example/group/project.git")
+    monkeypatch.setenv("PAGES_BRANCH", "gl-pages")
+
+    result = subprocess.run(
+        ["sh", "-eu", "-c", script],
+        text=True,
+        capture_output=True,
+    )
+
+    return result, commands_file.read_text(encoding="utf-8").splitlines()
+
+
+def test_existing_storage_branch_is_cloned(tmp_path, monkeypatch):
+    result, commands = run_storage_checkout_script(tmp_path, monkeypatch, branch_status=0)
+
+    assert result.returncode == 0
+    assert (
+        "clone --single-branch --branch gl-pages "
+        "https://gitlab.example/group/project.git pages-worktree"
+    ) in commands
+    assert not any(command.startswith("init ") for command in commands)
+
+
+def test_missing_storage_branch_is_created_as_orphan(tmp_path, monkeypatch):
+    result, commands = run_storage_checkout_script(tmp_path, monkeypatch, branch_status=2)
+
+    assert result.returncode == 0
+    assert "Storage branch 'gl-pages' does not exist; creating it." in result.stdout
+    assert "init pages-worktree" in commands
+    assert (
+        "-C pages-worktree remote add origin "
+        "https://gitlab.example/group/project.git"
+    ) in commands
+    assert "-C pages-worktree checkout --orphan gl-pages" in commands
+    assert not any(command.startswith("clone ") for command in commands)
+
+
+def test_storage_branch_check_failure_is_not_treated_as_missing(tmp_path, monkeypatch):
+    result, commands = run_storage_checkout_script(
+        tmp_path,
+        monkeypatch,
+        branch_status=128,
+    )
+
+    assert result.returncode == 1
+    assert "Failed to check storage branch 'gl-pages'." in result.stdout
+    assert not any(command.startswith(("clone ", "init ")) for command in commands)
+
+
+def run_pages_publish_script(
+    tmp_path,
+    monkeypatch,
+    successful_push,
+    remote_branch_exists=True,
+):
     template = Path("templates/gitlab-allure-history.yml").read_text(encoding="utf-8")
     script = extract_script_block(
         template,
@@ -195,6 +282,9 @@ def run_pages_publish_script(tmp_path, monkeypatch, successful_push):
             case "$command" in
               diff)
                 exit 1
+                ;;
+              ls-remote)
+                [ "$REMOTE_BRANCH_EXISTS" = "true" ] || exit 2
                 ;;
               pull)
                 printf 'pull\n' >> "$GIT_CALLS"
@@ -229,6 +319,10 @@ def run_pages_publish_script(tmp_path, monkeypatch, successful_push):
     monkeypatch.setenv("GIT_CALLS", str(calls_file))
     monkeypatch.setenv("GIT_COMMANDS", str(commands_file))
     monkeypatch.setenv("SUCCESSFUL_PUSH", str(successful_push))
+    monkeypatch.setenv(
+        "REMOTE_BRANCH_EXISTS",
+        "true" if remote_branch_exists else "false",
+    )
     monkeypatch.setenv("GIT_PUSH_TOKEN", "secret")
     monkeypatch.setenv("CI_SERVER_HOST", "gitlab.example")
     monkeypatch.setenv("CI_PROJECT_PATH", "group/project")
@@ -276,6 +370,19 @@ def test_pages_push_retries_after_racing_updates(tmp_path, monkeypatch):
         command.endswith("push -o ci.skip origin HEAD:gl-pages")
         for command in commands
     ) == 3
+
+
+def test_first_storage_push_does_not_pull_missing_branch(tmp_path, monkeypatch):
+    result, calls_file, _ = run_pages_publish_script(
+        tmp_path,
+        monkeypatch,
+        successful_push=1,
+        remote_branch_exists=False,
+    )
+
+    assert result.returncode == 0
+    assert calls_file.read_text(encoding="utf-8").splitlines() == ["push"]
+    assert (tmp_path / "public" / "index.html").is_file()
 
 
 def test_pages_push_fails_after_three_attempts(tmp_path, monkeypatch):

--- a/tests/test_gitlab_template.py
+++ b/tests/test_gitlab_template.py
@@ -114,12 +114,15 @@ def test_project_pipeline_validates_expanded_component_with_ci_lint_api():
     assert "requires `ALLURE_HISTORY_TOKEN` with `api` scope" in contributing
 
 
-def test_project_pipeline_smokes_published_pages_after_allure():
+def test_project_pipeline_smokes_published_pages_after_publish_job():
     pipeline = Path(".gitlab-ci.yml").read_text(encoding="utf-8")
 
     assert "pages_smoke:\n  stage: release\n" in pipeline
     assert "    - job: test_gate\n      artifacts: true" in pipeline
-    assert "    - job: allure\n      artifacts: false" in pipeline
+    assert (
+        "    - job: publish-allure-history\n"
+        "      artifacts: false"
+    ) in pipeline
     assert '        --base-url "$CI_PAGES_URL"' in pipeline
     assert '        --environment "$ENV"' in pipeline
     assert '        --branch "$CI_COMMIT_REF_SLUG"' in pipeline
@@ -160,19 +163,19 @@ def test_template_defines_component_inputs():
     assert "---\n\nvariables:" in template
 
 
-def test_allure_job_publishes_public_as_gitlab_pages_artifact():
+def test_publish_job_publishes_public_as_gitlab_pages_artifact():
     template = Path("templates/gitlab-allure-history.yml").read_text(encoding="utf-8")
-    allure_job = template.split("\nallure:\n", 1)[1]
+    publish_job = template.split("\npublish-allure-history:\n", 1)[1]
 
-    assert "\n  pages: true\n" in allure_job
+    assert "\n  pages: true\n" in publish_job
     assert (
         "  artifacts:\n"
         "    when: always\n"
         "    expire_in: 1 week\n"
         "    paths:\n"
         "      - public\n"
-    ) in allure_job
-    assert "\npublish-allure-history:" not in template
+    ) in publish_job
+    assert "\nallure:" not in template
     assert "\n  tags:" not in template
 
 

--- a/tests/test_validate_gitlab_ci.py
+++ b/tests/test_validate_gitlab_ci.py
@@ -11,9 +11,9 @@ def valid_lint_result():
         "valid": True,
         "errors": [],
         "warnings": [],
-        "merged_yaml": "allure:\n  script:\n    - echo report\n",
+        "merged_yaml": "publish-allure-history:\n  script:\n    - echo report\n",
         "includes": [{"type": "component", "location": "component.yml"}],
-        "jobs": [{"name": "test_gate"}, {"name": "allure"}],
+        "jobs": [{"name": "test_gate"}, {"name": "publish-allure-history"}],
     }
 
 
@@ -74,7 +74,7 @@ def test_fetch_lint_result_uses_optional_private_token(monkeypatch):
         ("valid", False, "configuration is invalid"),
         ("includes", [], "did not expand any includes"),
         ("merged_yaml", "", "did not return merged YAML"),
-        ("jobs", [], "missing the allure job"),
+        ("jobs", [], "missing the publish-allure-history job"),
     ],
 )
 def test_validate_lint_result_rejects_incomplete_validation(field, value, message):

--- a/validate_gitlab_ci.py
+++ b/validate_gitlab_ci.py
@@ -62,8 +62,11 @@ def validate_lint_result(result: dict[str, object]) -> None:
         for job in jobs
         if isinstance(job, dict) and isinstance(job.get("name"), str)
     }
-    if "allure" not in job_names:
-        raise RuntimeError("Expanded component configuration is missing the allure job")
+    if "publish-allure-history" not in job_names:
+        raise RuntimeError(
+            "Expanded component configuration is missing the "
+            "publish-allure-history job"
+        )
 
     print(
         "GitLab CI configuration is valid: "


### PR DESCRIPTION
## Summary

- publish GitLab Pages from the `publish-allure-history` component job
- keep `gl-pages` only as persistent report storage
- create the storage branch automatically on first publish
- skip CI for storage commits and pushes
- remove legacy `.gitlab-ci.yml` from the storage branch
- retain the generated `public/` tree as the Pages artifact
- update documentation